### PR TITLE
Reduce the sql statement in the deployments page

### DIFF
--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -2,12 +2,12 @@
 
 namespace App;
 
-use Lang;
+use App\Contracts\RuntimeInterface;
+use App\Presenters\DeploymentPresenter;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Lang;
 use Robbo\Presenter\PresentableInterface;
-use App\Presenters\DeploymentPresenter;
-use App\Contracts\RuntimeInterface;
 
 /**
  * Deployment model.
@@ -17,10 +17,12 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
     use SoftDeletes;
 
     const COMPLETED = 0;
-    const PENDING = 1;
+    const PENDING   = 1;
     const DEPLOYING = 2;
-    const FAILED = 3;
-    const LOADING = 'Loading';
+    const FAILED    = 3;
+    const LOADING   = 'Loading';
+
+    public static $currentDeployment = [];
 
     /**
      * The fields which should be tried as Carbon instances.
@@ -35,7 +37,7 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
      * @var array
      */
     protected $casts = [
-        'status' => 'integer'
+        'status' => 'integer',
     ];
 
     /**
@@ -95,12 +97,14 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
      */
     public function isCurrent()
     {
-        $latest = self::where('project_id', $this->project_id)
-                            ->where('status', self::COMPLETED)
-                            ->orderBy('id', 'desc')
-                            ->first();
+        if (!isset(self::$currentDeployment[$this->project_id])) {
+            self::$currentDeployment[$this->project_id] = self::where('project_id', $this->project_id)
+                ->where('status', self::COMPLETED)
+                ->orderBy('id', 'desc')
+                ->first();
+        }
 
-        return ($latest->id === $this->id);
+        return (self::$currentDeployment[$this->project_id]->id === $this->id);
     }
 
     /**
@@ -127,7 +131,7 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
         if ($this->commit != self::LOADING) {
             $info = $this->project->accessDetails();
             if (isset($info['domain']) && isset($info['reference'])) {
-                return 'http://'.$info['domain'].'/'.$info['reference'].'/commit/'.$this->commit;
+                return 'http://' . $info['domain'] . '/' . $info['reference'] . '/commit/' . $this->commit;
             }
         }
 
@@ -160,7 +164,7 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
         $info = $this->project->accessDetails();
 
         if (isset($info['domain']) && isset($info['reference'])) {
-            return 'http://'.$info['domain'].'/'.$info['reference'].'/tree/'.$this->branch;
+            return 'http://' . $info['domain'] . '/' . $info['reference'] . '/tree/' . $this->branch;
         }
 
         return false;
@@ -173,25 +177,25 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
      */
     public function notificationPayload()
     {
-        $colour = 'good';
+        $colour  = 'good';
         $message = Lang::get('notifications.success_message');
 
         if ($this->status === self::FAILED) {
-            $colour = 'danger';
+            $colour  = 'danger';
             $message = Lang::get('notifications.failed_message');
         }
 
         $payload = [
             'attachments' => [
                 [
-                    'fallback' => sprintf($message, '#'.$this->id),
+                    'fallback' => sprintf($message, '#' . $this->id),
                     'text'     => sprintf($message, sprintf('<%s|#%u>', url('deployment', $this->id), $this->id)),
                     'color'    => $colour,
                     'fields'   => [
                         [
                             'title' => Lang::get('notifications.project'),
                             'value' => sprintf('<%s|%s>', url('project', $this->project_id), $this->project->name),
-                            'short' => true
+                            'short' => true,
                         ], [
                             'title' => Lang::get('notifications.commit'),
                             'value' => $this->commitURL() ? sprintf(
@@ -199,19 +203,19 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
                                 $this->commitURL(),
                                 $this->shortCommit()
                             ) : $this->shortCommit(),
-                            'short' => true
+                            'short' => true,
                         ], [
                             'title' => Lang::get('notifications.committer'),
                             'value' => $this->committer,
-                            'short' => true
+                            'short' => true,
                         ], [
                             'title' => Lang::get('notifications.branch'),
                             'value' => $this->project->branch,
-                            'short' => true
-                        ]
-                    ]
-                ]
-            ]
+                            'short' => true,
+                        ],
+                    ],
+                ],
+            ],
         ];
 
         return $payload;

--- a/app/Repositories/EloquentDeploymentRepository.php
+++ b/app/Repositories/EloquentDeploymentRepository.php
@@ -2,10 +2,10 @@
 
 namespace App\Repositories;
 
-use App\Project;
 use App\Deployment;
-use Carbon\Carbon;
+use App\Project;
 use App\Repositories\Contracts\DeploymentRepositoryInterface;
+use Carbon\Carbon;
 
 /**
  * The deployment repository.
@@ -21,8 +21,9 @@ class EloquentDeploymentRepository implements DeploymentRepositoryInterface
     public function getLatest(Project $project)
     {
         return Deployment::where('project_id', $project->id)
-                         ->orderBy('started_at', 'DESC')
-                         ->paginate($project->builds_to_keep);
+            ->with('user', 'project')
+            ->orderBy('started_at', 'DESC')
+            ->paginate($project->builds_to_keep);
     }
 
     /**
@@ -35,9 +36,9 @@ class EloquentDeploymentRepository implements DeploymentRepositoryInterface
         $raw_sql = 'project_id IN (SELECT id FROM projects WHERE deleted_at IS NULL)';
 
         return Deployment::whereRaw($raw_sql)
-                         ->take(15)
-                         ->orderBy('started_at', 'DESC')
-                         ->get();
+            ->take(15)
+            ->orderBy('started_at', 'DESC')
+            ->get();
     }
 
     /**
@@ -83,7 +84,7 @@ class EloquentDeploymentRepository implements DeploymentRepositoryInterface
      */
     public function getLastWeekCount(Project $project)
     {
-        $lastWeek = Carbon::now()->subWeek();
+        $lastWeek  = Carbon::now()->subWeek();
         $yesterday = Carbon::now()->yesterday();
 
         return $this->getBetweenDates($project, $lastWeek, $yesterday);
@@ -100,9 +101,9 @@ class EloquentDeploymentRepository implements DeploymentRepositoryInterface
     private function getBetweenDates(Project $project, Carbon $startDate, Carbon $endDate)
     {
         return Deployment::where('project_id', $project->id)
-                         ->where('started_at', '>=', $startDate->format('Y-m-d').' 00:00:00')
-                         ->where('started_at', '<=', $endDate->format('Y-m-d').' 23:59:59')
-                         ->count();
+            ->where('started_at', '>=', $startDate->format('Y-m-d') . ' 00:00:00')
+            ->where('started_at', '<=', $endDate->format('Y-m-d') . ' 23:59:59')
+            ->count();
     }
 
     /**
@@ -116,8 +117,8 @@ class EloquentDeploymentRepository implements DeploymentRepositoryInterface
         $raw_sql = 'project_id IN (SELECT id FROM projects WHERE deleted_at IS NULL)';
 
         return Deployment::whereRaw($raw_sql)
-                         ->where('status', $status)
-                         ->orderBy('started_at', 'DESC')
-                         ->get();
+            ->where('status', $status)
+            ->orderBy('started_at', 'DESC')
+            ->get();
     }
 }

--- a/app/Repositories/EloquentDeploymentRepository.php
+++ b/app/Repositories/EloquentDeploymentRepository.php
@@ -36,6 +36,7 @@ class EloquentDeploymentRepository implements DeploymentRepositoryInterface
         $raw_sql = 'project_id IN (SELECT id FROM projects WHERE deleted_at IS NULL)';
 
         return Deployment::whereRaw($raw_sql)
+            ->with('project')
             ->take(15)
             ->orderBy('started_at', 'DESC')
             ->get();

--- a/resources/views/projects/_partials/deployments.blade.php
+++ b/resources/views/projects/_partials/deployments.blade.php
@@ -2,7 +2,7 @@
     <div class="box-header">
         <h3 class="box-title">{{ Lang::get('deployments.latest') }}</h3>
     </div>
-    
+
     @if (!count($deployments))
     <div class="box-body">
         <p>{{ Lang::get('deployments.none') }}</p>
@@ -67,5 +67,4 @@
     </div>
 
     @endif
-    
 </div>


### PR DESCRIPTION
By using a static variable, I reduce the sql statements from 48 to 21
in the deployments page.