### PR TITLE
Reconnect the database when queue is running as a daemon

### DIFF
--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -17,6 +17,7 @@ use REBELinBLUE\Deployer\Server;
 use REBELinBLUE\Deployer\ServerLog;
 use REBELinBLUE\Deployer\User;
 use Symfony\Component\Process\Process;
+use DB;
 
 /**
  * Deploys an actual project.
@@ -60,6 +61,7 @@ class DeployProject extends Job implements SelfHandling, ShouldQueue
      */
     public function handle()
     {
+        DB::reconnect();
         $project = $this->deployment->project;
 
         $this->deployment->started_at = date('Y-m-d H:i:s');

--- a/app/Jobs/RequestProjectCheckUrl.php
+++ b/app/Jobs/RequestProjectCheckUrl.php
@@ -9,6 +9,7 @@ use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use REBELinBLUE\Deployer\Jobs\Job;
+use DB;
 
 /**
  * Request the urls.
@@ -36,6 +37,7 @@ class RequestProjectCheckUrl extends Job implements SelfHandling, ShouldQueue
      */
     public function handle()
     {
+        DB::reconnect();
         foreach ($this->links as $link) {
             $response = Request::get($link->url)->send();
 

--- a/app/Jobs/TestServerConnection.php
+++ b/app/Jobs/TestServerConnection.php
@@ -9,6 +9,7 @@ use Illuminate\Queue\SerializesModels;
 use REBELinBLUE\Deployer\Jobs\Job;
 use REBELinBLUE\Deployer\Server;
 use Symfony\Component\Process\Process;
+use DB;
 
 /**
  * Tests if a server can successfully be SSHed into.
@@ -37,6 +38,7 @@ class TestServerConnection extends Job implements SelfHandling, ShouldQueue
      */
     public function handle()
     {
+        DB::reconnect();
         $this->server->status = Server::TESTING;
         $this->server->save();
 

--- a/app/Listeners/Events/EmailChangeConfirmation.php
+++ b/app/Listeners/Events/EmailChangeConfirmation.php
@@ -8,6 +8,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Mail;
 use REBELinBLUE\Deployer\Events\EmailChangeRequested;
+use DB;
 
 /**
  * Request email change handler.
@@ -33,6 +34,7 @@ class EmailChangeConfirmation implements ShouldQueue
      */
     public function handle(EmailChangeRequested $event)
     {
+        DB::reconnect();
         $user = $event->user;
 
         $data = [

--- a/app/Listeners/Events/Notify.php
+++ b/app/Listeners/Events/Notify.php
@@ -9,6 +9,7 @@ use REBELinBLUE\Deployer\Events\DeployFinished;
 use REBELinBLUE\Deployer\Jobs\MailDeployNotification;
 use REBELinBLUE\Deployer\Jobs\Notify as SlackNotify;
 use REBELinBLUE\Deployer\Jobs\RequestProjectCheckUrl;
+use DB;
 
 /**
  * When a deploy finished, notify the followed user.
@@ -35,6 +36,7 @@ class Notify extends Event implements ShouldQueue
      */
     public function handle(DeployFinished $event)
     {
+        DB::reconnect();
         $project    = $event->project;
         $deployment = $event->deployment;
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,6 +5,9 @@ namespace REBELinBLUE\Deployer\Providers;
 use Illuminate\Contracts\Auth\Access\Gate as GateContract;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
+/**
+ * Add auth policy provider
+ */
 class AuthServiceProvider extends ServiceProvider
 {
     /**


### PR DESCRIPTION
Because of the queue running as the daemon, the database connection
will be lost. Because of the connection is a single instance, but the
database socket will be lost.