### PR TITLE
Experimenting with adding toast alerts

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
         "socket.io-client": "~1.3.6",
         "html5shiv": "~3.7.2",
         "respond": "~1.4.2",
-        "cropper": "~0.10.0"
+        "cropper": "~0.10.0",
+        "toastr": "~2.1.2"
     }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,7 @@ var paths = {
     'html5shiv'       : bower_path + '/html5shiv',
     'respond'         : bower_path + '/respond',
     'cropper'         : bower_path + '/cropper',
+    'toastr'          : bower_path + '/toastr',
 };
 
 // To stop the google font imports from breaking
@@ -33,7 +34,8 @@ elixir(function(mix) {
     })
     .styles([
         'public/css/vendor.css',
-        paths.cropper + '/dist/cropper.min.css'
+        paths.toastr + '/toastr.css',
+        paths.cropper + '/dist/cropper.min.css',
     ], 'public/css/vendor.css', './')
     .styles([
         'AdminLTE.css',
@@ -52,6 +54,7 @@ elixir(function(mix) {
         paths.bootstrap       + '/javascripts/bootstrap.js',
         paths.backbone        + '/backbone.js',
         paths.socketio_client + '/socket.io.js',
+        paths.toastr          + '/toastr.js',
         paths.ace             + '/ace.js',
         paths.ace             + '/mode-sh.js',
         paths.ace             + '/mode-php.js',

--- a/resources/assets/css/app.css
+++ b/resources/assets/css/app.css
@@ -26,6 +26,10 @@
     content: "\f00c";
 }
 
+#toast-container > .toast-warning {
+    background-color: #51a351 !important;
+}
+
 
 #log pre {
     max-height: 300px;

--- a/resources/assets/css/app.css
+++ b/resources/assets/css/app.css
@@ -1,4 +1,33 @@
-#log pre { 
+
+#toast-container > .toast {
+    background-image: none !important;
+}
+
+#toast-container > .toast:before {
+    position: fixed;
+    font-family: FontAwesome;
+    font-size: 24px;
+    line-height: 18px;
+    float: left;
+    color: #FFF;
+    padding-right: 0.5em;
+    margin: auto 0.5em auto -1.5em;
+}
+#toast-container > .toast-warning:before {
+    content: "\f071";
+}
+#toast-container > .toast-error:before {
+    content: "\f071";
+}
+/*#toast-container > .toast-info:before {
+    content: "\f005";
+}*/
+#toast-container > .toast-success:before {
+    content: "\f00c";
+}
+
+
+#log pre {
     max-height: 300px;
     overflow: auto;
 }
@@ -69,7 +98,7 @@ input[type=text].deployment-source {
 }
 
 #command_script,
-#project-file-content { 
+#project-file-content {
     height: 250px;
 }
 
@@ -95,7 +124,7 @@ input[type=text].deployment-source {
     margin-right: 0;
 }
 
-#socket_offline { 
+#socket_offline {
     margin-top: 15px;
     display: none;
 }

--- a/resources/assets/css/app.css
+++ b/resources/assets/css/app.css
@@ -1,4 +1,3 @@
-
 #toast-container > .toast {
     background-image: none !important;
 }
@@ -13,15 +12,15 @@
     padding-right: 0.5em;
     margin: auto 0.5em auto -1.5em;
 }
+
 #toast-container > .toast-warning:before {
     content: "\f071";
 }
+
 #toast-container > .toast-error:before {
     content: "\f071";
 }
-/*#toast-container > .toast-info:before {
-    content: "\f005";
-}*/
+
 #toast-container > .toast-success:before {
     content: "\f00c";
 }
@@ -29,7 +28,6 @@
 #toast-container > .toast-warning {
     background-color: #51a351 !important;
 }
-
 
 #log pre {
     max-height: 300px;
@@ -106,7 +104,6 @@ input[type=text].deployment-source {
     height: 250px;
 }
 
-
 #preview-content {
     height: 500px;
     max-height: 500px;
@@ -136,20 +133,22 @@ input[type=text].deployment-source {
 #show_help {
     cursor: pointer;
 }
+
 .edit-profile .form-control {
     height: auto;
 }
+
 .avatar-preview {
     background-color: #f7f7f7;
     overflow: hidden;
     width: 100%;
     text-align: center;
 }
+
 .preview-md,
 .current-avatar-preview {
     width: 160px;
     height: 160px;
     margin-bottom: 15px;
-
-  border-radius: 50%;
+    border-radius: 50%;
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -4,6 +4,15 @@ $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
 
 var app = app || {};
 
+toastr.options.closeButton = true;
+//toastr.options.progressBar = true;
+toastr.options.closeMethod = 'fadeOut';
+toastr.options.closeDuration = 300;
+toastr.options.closeEasing = 'swing';
+toastr.options.positionClass = 'toast-bottom-right';
+toastr.options.timeOut = 30000; // How long the toast will display without user interaction
+toastr.options.extendedTimeOut = 60000;
+
 (function ($) {
 
     // Don't need to try and connect to the web socket when not logged in
@@ -109,6 +118,15 @@ var app = app || {};
             status.attr('class', 'label label-' + label_class)
             $('i', status).attr('class', 'fa fa-' + icon_class);
             $('span', status).text(label);
+        } else if ($('#timeline').length === 0) { // Don't show on dashboard
+            // FIXME: Also don't show if viewing the deployment, or the project the deployment is for
+            if (data.model.status === DEPLOYMENT_COMPLETED) {
+                toastr.success('Deployment #' + data.model.id + ' - Completed', data.model.project_name);
+            } else if (data.model.status === DEPLOYMENT_FAILED) {
+                toastr.error('Deployment #' + data.model.id + ' - Failed', data.model.project_name);
+            } else if (data.model.status === DEPLOYMENT_ERRORS) {
+                toastr.warning('Deployment #' + data.model.id + ' - Finished with errors', data.model.project_name);
+            }
         }
     });
 

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -5,13 +5,14 @@ $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
 var app = app || {};
 
 toastr.options.closeButton = true;
-//toastr.options.progressBar = true;
+toastr.options.progressBar = true;
+toastr.options.preventDuplicates = true;
 toastr.options.closeMethod = 'fadeOut';
 toastr.options.closeDuration = 300;
 toastr.options.closeEasing = 'swing';
 toastr.options.positionClass = 'toast-bottom-right';
-toastr.options.timeOut = 30000; // How long the toast will display without user interaction
-toastr.options.extendedTimeOut = 60000;
+toastr.options.timeOut = 5000;
+toastr.options.extendedTimeOut = 7000;
 
 (function ($) {
 
@@ -64,9 +65,9 @@ toastr.options.extendedTimeOut = 60000;
     app.listener.on('deployment:REBELinBLUE\\Deployer\\Events\\ModelChanged', function (data) {
         updateNavBar(data);
 
-        var project = $('#project_' + data.model.project_id);
+        //var project = $('#project_' + data.model.project_id);
 
-        if (project.length > 0) {
+        if ($('#timeline').length > 0) {
             updateTimeline();
         }
 
@@ -121,11 +122,11 @@ toastr.options.extendedTimeOut = 60000;
         } else if ($('#timeline').length === 0) { // Don't show on dashboard
             // FIXME: Also don't show if viewing the deployment, or the project the deployment is for
             if (data.model.status === DEPLOYMENT_COMPLETED) {
-                toastr.success('Deployment #' + data.model.id + ' - Completed', data.model.project_name);
+                toastr.success(Lang.toast.title.replace(':id', data.model.id) + ' - ' + Lang.toast.completed, data.model.project_name);
             } else if (data.model.status === DEPLOYMENT_FAILED) {
-                toastr.error('Deployment #' + data.model.id + ' - Failed', data.model.project_name);
+                toastr.error(Lang.toast.title.replace(':id', data.model.id) + ' - ' + Lang.toast.failed, data.model.project_name);
             } else if (data.model.status === DEPLOYMENT_ERRORS) {
-                toastr.warning('Deployment #' + data.model.id + ' - Finished with errors', data.model.project_name);
+                toastr.warning(Lang.toast.title.replace(':id', data.model.id) + ' - ' + Lang.toast.completed_with_errors, data.model.project_name);
             }
         }
     });
@@ -212,7 +213,7 @@ toastr.options.extendedTimeOut = 60000;
         var pending = $('#pending_menu ul.menu li').length;
         var deploying = $('#deploying_menu ul.menu li').length;
 
-        var pending_label = Lang.nav.multi_pending.replace('%s', pending);
+        var pending_label = Lang.nav.multi_pending.replace(':count', pending);
         if (pending === 0) {
             $('#pending_menu').hide();
         }
@@ -220,7 +221,7 @@ toastr.options.extendedTimeOut = 60000;
             pending_label = Lang.nav.single_pending;
         }
 
-        var deploying_label = Lang.nav.multi_running.replace('%s', deploying);
+        var deploying_label = Lang.nav.multi_running.replace(':count', deploying);
         if (deploying === 0) {
             $('#deploying_menu').hide();
         }

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -60,9 +60,16 @@
         <script type="text/javascript">
             Lang.nav = {
                 single_pending: '{{ Lang::choice('dashboard.pending', 1) }}',
-                multi_pending: '{{ Lang::choice('dashboard.pending', '%s') }}',
+                multi_pending: '{{ Lang::choice('dashboard.pending', ':count') }}',
                 single_running: '{{ Lang::choice('dashboard.running', 1) }}',
-                multi_running: '{{ Lang::choice('dashboard.running', '%s') }}'
+                multi_running: '{{ Lang::choice('dashboard.running', ':count') }}'
+            };
+
+            Lang.toast = {
+                title: '{{ Lang::get('dashboard.deployment_number') }}',
+                completed: '{{ Lang::get('deployments.completed') }}',
+                completed_with_errors: '{{ Lang::get('deployments.completed_with_errors') }}',
+                failed: '{{ Lang::get('deployments.failed') }}'
             };
         </script>
 


### PR DESCRIPTION
Something like this

![alerts](https://s3.amazonaws.com/f.cl.ly/items/0k3z1y060z0Z2N473p1e/Image%202015-10-17%20at%2011.32.18%20p.m..png)


What do you think @dancryer? 

The orange one will actually be green (and should say Finished with errors), like it is elsewhere and they won't show if you are viewing the dashboard; the results for projects you are viewing won't show or the specific deployment you are viewing

i.e. if you are viewing /projects/1 you won't get an alert for any deployments for that project as you can see it in the list, and if you are viewing /deployment/1 you won't get an alert when that finishes, but you will for any others which belong to the same project