### PR TITLE
Mirroring repositories locally to deployer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -5,7 +5,6 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->in('app')
     ->in('database')
     ->name('*.php')
-    ->notName('Kernel.php') // There has to be a better way to do this!
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 

--- a/.phpci.yml
+++ b/.phpci.yml
@@ -10,6 +10,7 @@ build_settings:
         - "storage"
         - "tests"
         - "vendor"
+        - "create-release"
 
 setup:
     wipe:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,6 +59,9 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: "sudo apt-get install ruby ruby-dev -y"
     config.vm.provision "shell", inline: "sudo gem install github_changelog_generator -v 1.11.3"
 
+    # Install JS CS
+    config.vm.provision "shell", inline: "sudo npm install jscs -g"
+
     # Create DB
     config.vm.provision "shell", inline: "mysql -uhomestead -psecret -e 'DROP DATABASE IF EXISTS deployer'"
     config.vm.provision "shell", inline: "mysql -uhomestead -psecret -e 'CREATE DATABASE deployer DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci'"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,9 +59,6 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: "sudo apt-get install ruby ruby-dev -y"
     config.vm.provision "shell", inline: "sudo gem install github_changelog_generator -v 1.11.3"
 
-    # Install JS CS
-    config.vm.provision "shell", inline: "sudo npm install jscs -g"
-
     # Create DB
     config.vm.provision "shell", inline: "mysql -uhomestead -psecret -e 'DROP DATABASE IF EXISTS deployer'"
     config.vm.provision "shell", inline: "mysql -uhomestead -psecret -e 'CREATE DATABASE deployer DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci'"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,6 +99,8 @@ Vagrant.configure("2") do |config|
     config.vm.provision "shell", inline: "echo 'alias phpunit=\"php $(which phpunit)\"' >> /home/vagrant/.profile"
     config.vm.provision "shell", inline: "echo 'export PATH=/var/www/deployer/vendor/bin:$PATH' >> /home/vagrant/.profile"
 
+    config.vm.provision "shell", inline: "echo 'export PATH=/var/www/deployer/vendor/bin:$PATH' >> /home/vagrant/.profile"
+
     # Update composer on each boot
     config.vm.provision "shell", inline: "sudo /usr/local/bin/composer self-update", run: "always"
 end

--- a/app/Console/Commands/ClearOldKeys.php
+++ b/app/Console/Commands/ClearOldKeys.php
@@ -41,8 +41,8 @@ class ClearOldKeys extends Command
     public function handle()
     {
         // Clear out old SSH key files
-        $files   = glob(storage_path() . '/app/*ssh*'); // sshkey and gitssh
-        $folders = glob(storage_path() . '/app/*clone*'); // cloned copies of code
+        $files   = glob(storage_path('app/') . '*ssh*'); // sshkey and gitssh
+        $folders = glob(storage_path('app/') . '*clone*'); // cloned copies of code
 
         $this->info('Found ' . count($files) . ' files and ' . count($folders) . ' folders to purge');
 

--- a/app/Console/Commands/ClearOrphanMirrors.php
+++ b/app/Console/Commands/ClearOrphanMirrors.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace REBELinBLUE\Deployer\Console\Commands;
+
+use Illuminate\Console\Command;
+
+/**
+ * Checks for and cleans up orphaned git mirrors
+ */
+class ClearOrphanMirrors extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'deployer:purge-mirrors';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Purges git mirrors which are no longer in use by projects';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        //
+    }
+}

--- a/app/Console/Commands/ClearOrphanMirrors.php
+++ b/app/Console/Commands/ClearOrphanMirrors.php
@@ -61,7 +61,6 @@ class ClearOrphanMirrors extends Command
 
         // Now loop through the mirrors and delete them from storage
         foreach ($orphan_mirrors as $mirror_dir) {
-
             $process = new Process("rm -rf {$mirror_dir}");
             $process->setTimeout(null);
             $process->run();
@@ -72,6 +71,5 @@ class ClearOrphanMirrors extends Command
                 $this->info('Failed to delete ' . basename($mirror_dir));
             }
         }
-
     }
 }

--- a/app/Console/Commands/ClearOrphanMirrors.php
+++ b/app/Console/Commands/ClearOrphanMirrors.php
@@ -3,6 +3,8 @@
 namespace REBELinBLUE\Deployer\Console\Commands;
 
 use Illuminate\Console\Command;
+use REBELinBLUE\Deployer\Project;
+use Symfony\Component\Process\Process;
 
 /**
  * Checks for and cleans up orphaned git mirrors.
@@ -40,6 +42,36 @@ class ClearOrphanMirrors extends Command
      */
     public function handle()
     {
-        //
+        $current_mirrors = [];
+
+        Project::where('is_template', false)->chunk(10, function ($projects) use (&$current_mirrors) {
+            foreach ($projects as $project) {
+                $current_mirrors[] = $project->mirrorPath();
+            }
+        });
+
+        $current_mirrors = collect($current_mirrors);
+
+        $all_mirrors = collect(glob(storage_path('app/mirrors/') . '*.git'));
+
+        // Compare the 2 collections get a list of mirrors which are no longer in use
+        $orphan_mirrors = $all_mirrors->diff($current_mirrors);
+
+        $this->info('Found ' . $orphan_mirrors->count() . ' orphaned mirrors');
+
+        // Now loop through the mirrors and delete them from storage
+        foreach ($orphan_mirrors as $mirror_dir) {
+
+            $process = new Process("rm -rf {$mirror_dir}");
+            $process->setTimeout(null);
+            $process->run();
+
+            if ($process->isSuccessful()) {
+                $this->info('Deleted ' . basename($mirror_dir));
+            } else {
+                $this->info('Failed to delete ' . basename($mirror_dir));
+            }
+        }
+
     }
 }

--- a/app/Console/Commands/ClearOrphanMirrors.php
+++ b/app/Console/Commands/ClearOrphanMirrors.php
@@ -5,7 +5,7 @@ namespace REBELinBLUE\Deployer\Console\Commands;
 use Illuminate\Console\Command;
 
 /**
- * Checks for and cleans up orphaned git mirrors
+ * Checks for and cleans up orphaned git mirrors.
  */
 class ClearOrphanMirrors extends Command
 {

--- a/app/Console/Commands/CreateUser.php
+++ b/app/Console/Commands/CreateUser.php
@@ -85,7 +85,7 @@ class CreateUser extends Command
             event(new UserWasCreated($user, $arguments['password']));
         } elseif ($password_generated) {
             $message .= ', however you elected to not email the account details to them. ';
-            $messate .= 'Their password is ' . $arguments['password'];
+            $message .= 'Their password is ' . $arguments['password'];
         }
 
         $this->info($message);

--- a/app/Console/Commands/CreateUser.php
+++ b/app/Console/Commands/CreateUser.php
@@ -84,7 +84,8 @@ class CreateUser extends Command
 
             event(new UserWasCreated($user, $arguments['password']));
         } elseif ($password_generated) {
-            $message .= ', however you elected to not email the account details to them. Their password is ' . $arguments['password'];
+            $message .= ', however you elected to not email the account details to them. ';
+            $messate .= 'Their password is ' . $arguments['password'];
         }
 
         $this->info($message);

--- a/app/Console/Commands/InstallApp.php
+++ b/app/Console/Commands/InstallApp.php
@@ -118,9 +118,9 @@ class InstallApp extends Command
         $this->line('');
         $this->comment('2. Setup the cronjobs, see "crontab"');
         $this->line('');
-        $this->comment('3. Setup the socket server and queue runner, see "supervisor.conf" for an example of how to do this with supervisor');
+        $this->comment('3. Setup the socket server & queue runner, see "supervisor.conf" for an example commands');
         $this->line('');
-        $this->comment('4. Ensure that "storage" and "public/upload" are writable by the webserver, for example run "chmod -R 777 storage"');
+        $this->comment('4. Ensure that "storage" and "public/upload" are writable by the webserver');
         $this->line('');
         $this->comment('5. (Optional) Setup logrotate, see "logrotate.conf"');
         $this->line('');
@@ -391,7 +391,8 @@ class InstallApp extends Command
         if (count($locales) === 1) {
             $locale = $locales[0];
         } else {
-            $locale = $this->choice('Language', $locales, array_search(Config::get('app.fallback_locale'), $locales, true));
+            $default = array_search(Config::get('app.fallback_locale'), $locales, true);
+            $locale = $this->choice('Language', $locales, $default);
         }
 
         return [
@@ -584,7 +585,9 @@ class InstallApp extends Command
         }
 
         if (!count($this->getDatabaseDrivers())) {
-            $this->error('At least 1 PDO database driver is required. Either sqlite, mysql, pgsql or sqlsrv, check your php.ini file');
+            $this->error(
+                'At least 1 PDO driver is required. Either sqlite, mysql, pgsql or sqlsrv, check your php.ini file'
+            );
             $errors = true;
         }
 
@@ -630,7 +633,7 @@ class InstallApp extends Command
 
         if ($errors) {
             $this->line('');
-            $this->block('Deployer cannot be installed, as not all requirements are met. Please review the errors above before continuing.');
+            $this->block('Deployer cannot be installed. Please review the errors above before continuing.');
             $this->line('');
 
             return false;

--- a/app/Console/Commands/InstallApp.php
+++ b/app/Console/Commands/InstallApp.php
@@ -392,7 +392,7 @@ class InstallApp extends Command
             $locale = $locales[0];
         } else {
             $default = array_search(Config::get('app.fallback_locale'), $locales, true);
-            $locale = $this->choice('Language', $locales, $default);
+            $locale  = $this->choice('Language', $locales, $default);
         }
 
         return [

--- a/app/Console/Commands/InstallApp.php
+++ b/app/Console/Commands/InstallApp.php
@@ -599,7 +599,7 @@ class InstallApp extends Command
         }
 
         // Programs needed in $PATH
-        $required_commands = ['ssh', 'ssh-keygen', 'git', 'scp', 'tar'];
+        $required_commands = ['ssh', 'ssh-keygen', 'git', 'scp', 'tar', 'gzip'];
 
         foreach ($required_commands as $command) {
             $process = new Process('which ' . $command);

--- a/app/Console/Commands/InstallApp.php
+++ b/app/Console/Commands/InstallApp.php
@@ -599,7 +599,7 @@ class InstallApp extends Command
         }
 
         // Programs needed in $PATH
-        $required_commands = ['ssh', 'ssh-keygen', 'git', 'scp'];
+        $required_commands = ['ssh', 'ssh-keygen', 'git', 'scp', 'tar'];
 
         foreach ($required_commands as $command) {
             $process = new Process('which ' . $command);

--- a/app/Console/Commands/UpdateApp.php
+++ b/app/Console/Commands/UpdateApp.php
@@ -43,7 +43,10 @@ class UpdateApp extends InstallApp
      */
     public function handle()
     {
-        if (!$this->verifyInstalled() || $this->hasRunningDeployments() || $this->composerOutdated() || !$this->checkRequirements()) {
+        if (!$this->verifyInstalled() ||
+            $this->hasRunningDeployments() ||
+            $this->composerOutdated() ||
+            !$this->checkRequirements()) {
             return;
         }
 

--- a/app/Console/Commands/UpdateGitMirrors.php
+++ b/app/Console/Commands/UpdateGitMirrors.php
@@ -49,14 +49,12 @@ class UpdateGitMirrors extends Command
      */
     public function handle()
     {
-        $command = $this;
-
         $last_mirrored_since = Carbon::now()->subMinutes(self::UPDATE_FREQUENCY_MINUTES);
         $todo                = self::UPDATES_TO_QUEUE;
 
-        Project::where('last_mirrored', '<', $last_mirrored_since)->chunk($todo, function ($projects) use ($command) {
+        Project::where('last_mirrored', '<', $last_mirrored_since)->chunk($todo, function ($projects) {
             foreach ($projects as $project) {
-                $command->dispatch(new UpdateGitMirror($project));
+                $this->dispatch(new UpdateGitMirror($project));
             }
         });
     }

--- a/app/Console/Commands/UpdateGitMirrors.php
+++ b/app/Console/Commands/UpdateGitMirrors.php
@@ -2,6 +2,7 @@
 
 namespace REBELinBLUE\Deployer\Console\Commands;
 
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use REBELinBLUE\Deployer\Jobs\UpdateGitMirror;
@@ -53,7 +54,7 @@ class UpdateGitMirrors extends Command
         $last_mirrored_since = Carbon::now()->subMinutes(self::UPDATE_FREQUENCY_MINUTES);
         $todo = self::UPDATES_TO_QUEUE;
 
-        CheckUrlModel::where('last_mirrored', '<', $last_mirrored_since)->chunk($todo, function ($project) use ($command) {
+        Project::where('last_mirrored', '<', $last_mirrored_since)->chunk($todo, function ($project) use ($command) {
             $command->dispatch(new UpdateGitMirror($project));
         });
     }

--- a/app/Console/Commands/UpdateGitMirrors.php
+++ b/app/Console/Commands/UpdateGitMirrors.php
@@ -54,8 +54,10 @@ class UpdateGitMirrors extends Command
         $last_mirrored_since = Carbon::now()->subMinutes(self::UPDATE_FREQUENCY_MINUTES);
         $todo                = self::UPDATES_TO_QUEUE;
 
-        Project::where('last_mirrored', '<', $last_mirrored_since)->chunk($todo, function ($project) use ($command) {
-            $command->dispatch(new UpdateGitMirror($project));
+        Project::where('last_mirrored', '<', $last_mirrored_since)->chunk($todo, function ($projects) use ($command) {
+            foreach ($projects as $project) {
+                $command->dispatch(new UpdateGitMirror($project));
+            }
         });
     }
 }

--- a/app/Console/Commands/UpdateGitMirrors.php
+++ b/app/Console/Commands/UpdateGitMirrors.php
@@ -9,13 +9,13 @@ use REBELinBLUE\Deployer\Jobs\UpdateGitMirror;
 use REBELinBLUE\Deployer\Project;
 
 /**
- * Updates the mirrors for all git repositories
+ * Updates the mirrors for all git repositories.
  */
 class UpdateGitMirrors extends Command
 {
     use DispatchesJobs;
 
-    const UPDATES_TO_QUEUE = 3;
+    const UPDATES_TO_QUEUE         = 3;
     const UPDATE_FREQUENCY_MINUTES = 5;
 
     /**
@@ -52,7 +52,7 @@ class UpdateGitMirrors extends Command
         $command = $this;
 
         $last_mirrored_since = Carbon::now()->subMinutes(self::UPDATE_FREQUENCY_MINUTES);
-        $todo = self::UPDATES_TO_QUEUE;
+        $todo                = self::UPDATES_TO_QUEUE;
 
         Project::where('last_mirrored', '<', $last_mirrored_since)->chunk($todo, function ($project) use ($command) {
             $command->dispatch(new UpdateGitMirror($project));

--- a/app/Console/Commands/UpdateGitMirrors.php
+++ b/app/Console/Commands/UpdateGitMirrors.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace REBELinBLUE\Deployer\Console\Commands;
+
+use Illuminate\Console\Command;
+
+/**
+ * Updates the mirrors for all git repositories
+ */
+class UpdateGitMirrors extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'deployer:update-mirrors';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Pulls in updates for git mirrors';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        //
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace REBELinBLUE\Deployer\Console;
 use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
 
 /**
  * Kernel class.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,10 +2,10 @@
 
 namespace REBELinBLUE\Deployer\Console;
 
-use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging as ConsoleLogging;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
+use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging as ConsoleLogging;
 
 /**
  * Kernel class.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,7 +2,7 @@
 
 namespace REBELinBLUE\Deployer\Console;
 
-use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
+use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging as ConsoleLogging;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
@@ -17,7 +17,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $customBooters = [
-        \Illuminate\Foundation\Bootstrap\ConfigureLogging::class => ConfigureLogging::class,
+        \Illuminate\Foundation\Bootstrap\ConfigureLogging::class => ConsoleLogging::class,
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -37,8 +37,10 @@ class Kernel extends ConsoleKernel
         \REBELinBLUE\Deployer\Console\Commands\CheckUrl::class,
         \REBELinBLUE\Deployer\Console\Commands\CreateUser::class,
         \REBELinBLUE\Deployer\Console\Commands\ClearOrphanAvatars::class,
+        \REBELinBLUE\Deployer\Console\Commands\ClearOrphanMirrors::class,
         \REBELinBLUE\Deployer\Console\Commands\ClearStalledDeployment::class,
         \REBELinBLUE\Deployer\Console\Commands\ClearOldKeys::class,
+        \REBELinBLUE\Deployer\Console\Commands\UpdateGitMirrors::class,
         \REBELinBLUE\Deployer\Console\Commands\InstallApp::class,
         \REBELinBLUE\Deployer\Console\Commands\UpdateApp::class,
         \REBELinBLUE\Deployer\Console\Commands\ResetApp::class,
@@ -57,6 +59,10 @@ class Kernel extends ConsoleKernel
                  ->everyFiveMinutes()
                  ->withoutOverlapping();
 
+        $schedule->command('deployer:update-mirrors')
+                 ->everyFiveMinutes()
+                 ->withoutOverlapping();
+
         $schedule->command('deployer:checkurls')
                  ->everyFiveMinutes()
                  ->withoutOverlapping();
@@ -65,6 +71,10 @@ class Kernel extends ConsoleKernel
                  ->weekly()
                  ->sundays()
                  ->at('00:30')
+                 ->withoutOverlapping();
+
+        $schedule->command('deployer:purge-mirrors')
+                 ->daily()
                  ->withoutOverlapping();
 
         $schedule->command('deployer:purge-temp')

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -108,6 +108,11 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
                     ->withTrashed();
     }
 
+    public function commands()
+    {
+        return $this->hasManyThrough(Command::class, DeployStep::class);
+    }
+
     /**
      * Has many relationship.
      *

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -137,7 +137,6 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
                              ->orderBy('order')
                              ->get(['commands.*', 'deployment_id']);
 
-
         $hasMany = new HasMany(Command::query(), $this, 'deployment_id', 'id');
         $hasMany->matchMany([$this], $collection, 'commands');
 

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -108,9 +108,15 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
                     ->withTrashed();
     }
 
+    /**
+     * Has Many Through relationship.
+     *
+     * @return Command
+     */
     public function commands()
     {
-        return $this->hasManyThrough(Command::class, DeployStep::class);
+        return $this->hasMany(DeployStep::class)->hasOne(Command::class);
+        //return $this->hasManyThrough(Command::class, DeployStep::class, 'deployment_id');
     }
 
     /**

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -35,7 +35,8 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
      *
      * @var array
      */
-    protected $fillable = ['reason', 'branch', 'project_id', 'source', 'build_url'];
+    protected $fillable = ['reason', 'branch', 'project_id', 'source', 'build_url',
+                           'commit', 'committer_email', 'committer', ];
 
     /**
      * The attributes excluded from the model's JSON form.

--- a/app/Deployment.php
+++ b/app/Deployment.php
@@ -139,8 +139,7 @@ class Deployment extends Model implements PresentableInterface, RuntimeInterface
 
 
         $hasMany = new HasMany(Command::query(), $this, 'deployment_id', 'id');
-
-        $hasMany->matchMany(array($this), $collection, 'commands');
+        $hasMany->matchMany([$this], $collection, 'commands');
 
         return $this;
     }

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -33,7 +33,7 @@ class UserController extends Controller
     {
         return view('admin.users.listing', [
             'title' => Lang::get('users.manage'),
-            'users' => $this->repository->getAll()->toJson(), // Because PresentableInterface toJson() is not working in the view
+            'users' => $this->repository->getAll()->toJson(), // PresentableInterface toJson() is not working in view
         ]);
     }
 

--- a/app/Http/Controllers/DeploymentController.php
+++ b/app/Http/Controllers/DeploymentController.php
@@ -161,12 +161,22 @@ class DeploymentController extends Controller
     /**
      * Loads a previous deployment and then creates a new deployment based on it.
      *
+     * @param  Request  $request
      * @param  int      $deployment_id
      * @return Response
      */
-    public function rollback($deployment_id)
+    public function rollback(Request $request, $deployment_id)
     {
-        $deployment = $this->deploymentRepository->rollback($deployment_id);
+        $optional = [];
+
+        // Get the optional commands and typecast to integers
+        if ($request->has('optional') && is_array($request->get('optional'))) {
+            $optional = array_filter(array_map(function ($value) {
+                return filter_var($value, FILTER_VALIDATE_INT);
+            }, $request->get('optional')));
+        }
+
+        $deployment = $this->deploymentRepository->rollback($deployment_id, $optional);
 
         return redirect()->route('deployment', [
             'id' => $deployment->id,

--- a/app/Http/Controllers/DeploymentController.php
+++ b/app/Http/Controllers/DeploymentController.php
@@ -159,6 +159,19 @@ class DeploymentController extends Controller
     }
 
     /**
+     * Loads a previous deployment and then creates a new deployment based on it.
+     *
+     * @param  int $deployment_id
+     * @return Response
+     */
+    public function rollback($deployment_id)
+    {
+        return redirect()->route('deployment', [
+            'id' => '?',
+        ]);
+    }
+
+    /**
      * Abort a deployment.
      *
      * @param  int      $deployment_id

--- a/app/Http/Controllers/DeploymentController.php
+++ b/app/Http/Controllers/DeploymentController.php
@@ -161,13 +161,15 @@ class DeploymentController extends Controller
     /**
      * Loads a previous deployment and then creates a new deployment based on it.
      *
-     * @param  int $deployment_id
+     * @param  int      $deployment_id
      * @return Response
      */
     public function rollback($deployment_id)
     {
+        $deployment = $this->deploymentRepository->rollback($deployment_id);
+
         return redirect()->route('deployment', [
-            'id' => '?',
+            'id' => $deployment->id,
         ]);
     }
 

--- a/app/Http/Controllers/DeploymentController.php
+++ b/app/Http/Controllers/DeploymentController.php
@@ -73,7 +73,7 @@ class DeploymentController extends Controller
             'checkUrls'     => $project->checkUrls,
             'variables'     => $project->variables,
             'optional'      => $optional,
-            'tags'          => $project->tags(),
+            'tags'          => $project->tags()->reverse(),
             'branches'      => $project->branches(),
             'route'         => 'commands',
         ]);

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,9 +2,9 @@
 
 namespace REBELinBLUE\Deployer\Http;
 
-use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging as HttpLogging;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
+use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging as HttpLogging;
 
 /**
  * Kernel class.

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -2,7 +2,7 @@
 
 namespace REBELinBLUE\Deployer\Http;
 
-use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
+use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging as HttpLogging;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
 
@@ -16,7 +16,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $customBooters = [
-        \Illuminate\Foundation\Bootstrap\ConfigureLogging::class => ConfigureLogging::class,
+        \Illuminate\Foundation\Bootstrap\ConfigureLogging::class => HttpLogging::class,
     ];
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -4,6 +4,7 @@ namespace REBELinBLUE\Deployer\Http;
 
 use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
+use REBELinBLUE\Deployer\Bootstrap\ConfigureLogging;
 
 /**
  * Kernel class.
@@ -66,11 +67,11 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        'auth' => \REBELinBLUE\Deployer\Http\Middleware\Authenticate::class,
-        'jwt' => \REBELinBLUE\Deployer\Http\Middleware\RefreshJsonWebToken::class,
+        'jwt'        => \REBELinBLUE\Deployer\Http\Middleware\RefreshJsonWebToken::class,
+        'auth'       => \REBELinBLUE\Deployer\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
-        'guest'  => \REBELinBLUE\Deployer\Http\Middleware\RedirectIfAuthenticated::class,
-        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'guest'      => \REBELinBLUE\Deployer\Http\Middleware\RedirectIfAuthenticated::class,
+        'throttle'   => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];
 
     /**

--- a/app/Http/Requests/StoreProjectRequest.php
+++ b/app/Http/Requests/StoreProjectRequest.php
@@ -32,12 +32,10 @@ class StoreProjectRequest extends Request
 
                 /*
                 TODO: improve these regexs, using the following stolen from PHPCI (sorry Dan!)
-
                 'ssh': /git\@github\.com\:([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-]+)\.git/,
                 'git': /git\:\/\/github.com\/([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-]+)\.git/,
                 'http': /https\:\/\/github\.com\/([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-]+)(\.git)?/
                 */
-
                 if (preg_match('/^[a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-\.]+$/', $value)) { // Github
                     return true;
                 }

--- a/app/Http/Routes/deployments.php
+++ b/app/Http/Routes/deployments.php
@@ -14,8 +14,7 @@ Route::group([
         'uses' => 'DeploymentController@deploy',
     ]);
 
-    // FIXME: Should be post
-    Route::get('deployment/{deployments}/rollback', [
+    Route::post('deployment/{deployments}/rollback', [
         'as'   => 'rollback',
         'uses' => 'DeploymentController@rollback',
     ]);

--- a/app/Http/Routes/deployments.php
+++ b/app/Http/Routes/deployments.php
@@ -14,6 +14,11 @@ Route::group([
         'uses' => 'DeploymentController@deploy',
     ]);
 
+    Route::post('deployment/{deployments}/rollback', [
+        'as'   => 'rollback',
+        'uses' => 'DeploymentController@rollback',
+    ]);
+
     Route::get('deployment/{deployments}/abort', [
         'as'   => 'abort',
         'uses' => 'DeploymentController@abort',

--- a/app/Http/Routes/deployments.php
+++ b/app/Http/Routes/deployments.php
@@ -14,7 +14,8 @@ Route::group([
         'uses' => 'DeploymentController@deploy',
     ]);
 
-    Route::post('deployment/{deployments}/rollback', [
+    // FIXME: Should be post
+    Route::get('deployment/{deployments}/rollback', [
         'as'   => 'rollback',
         'uses' => 'DeploymentController@rollback',
     ]);

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -158,7 +158,7 @@ class DeployProject extends Job implements ShouldQueue
         $cmd = <<< CMD
 chmod +x "{$wrapper}" && \
 export GIT_SSH="{$wrapper}" && \
-git clone --quiet --reference {$mirrorDir} --branch %s --depth 1 %s {$workingDir} && \
+git clone --recursive --quiet --reference {$mirrorDir} --branch %s --depth 1 %s {$workingDir} && \
 cd {$workingDir} && \
 git checkout %s --quiet && \
 git log --pretty=format:"%%H%%x09%%an%%x09%%ae"

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -388,7 +388,6 @@ CMD;
         $commands = false;
 
         if ($step->stage === Stage::DO_CLONE) {
-
             $this->sendFile($this->release_archive, $remote_archive, $server, $log);
 
             $commands = [
@@ -596,7 +595,6 @@ OUT;
             $remote_file
         );
 
-
         $process = new Process($copy);
         $process->setTimeout(null);
         ///$process->run();
@@ -606,8 +604,7 @@ OUT;
             if ($type === Process::ERR) {
                 $output .= $this->logError($output_line);
             } else {
-                $tokens = array('received' => 'sent', 'bytes  sent' => 'received');
-
+                // FIXME: Horrible hack
                 $output_line = str_replace('received', 'xxx', $output_line);
                 $output_line = str_replace('sent', 'received', $output_line);
                 $output_line = str_replace('xxx', 'sent', $output_line);

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -25,7 +25,6 @@ use Symfony\Component\Process\Process;
  * Deploys an actual project.
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * TODO: rewrite this as it is doing way too much and is very messy now.
- * TODO: Move gitWrapperScript somewhere else as it is duplicated in UpdateGitReferences
  * TODO: Expand all parameters
  */
 class DeployProject extends Job implements ShouldQueue
@@ -529,25 +528,6 @@ class DeployProject extends Job implements ShouldQueue
                  ' . $user . '@' . $server->ip_address . ' \'bash -s\' << \'EOF\'
                  ' . $script . '
 EOF';
-    }
-
-    /**
-     * Generates the content of a git bash script.
-     *
-     * @param  string $key_file_path The path to the public key to use
-     * @return string
-     */
-    private function gitWrapperScript($key_file_path)
-    {
-        return <<<OUT
-#!/bin/sh
-ssh -o CheckHostIP=no \
-    -o IdentitiesOnly=yes \
-    -o StrictHostKeyChecking=no \
-    -o PasswordAuthentication=no \
-    -o IdentityFile={$key_file_path} $*
-
-OUT;
     }
 
     /**

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -80,7 +80,7 @@ class DeployProject extends Job implements ShouldQueue
 
         $this->release_id = date('YmdHis', strtotime($this->deployment->started_at));
 
-        $this->private_key = tempnam(storage_path() . '/app/', 'sshkey');
+        $this->private_key = tempnam(storage_path('app/'), 'sshkey');
         file_put_contents($this->private_key, $project->private_key);
 
         $this->release_archive = storage_path('app/') . $this->deployment->project_id . '_' . $this->release_id . '.tar.gz';
@@ -146,10 +146,10 @@ class DeployProject extends Job implements ShouldQueue
 
         $mirrorDir = $this->deployment->project->mirrorPath();
 
-        $wrapper = tempnam(storage_path() . '/app/', 'gitssh');
+        $wrapper = tempnam(storage_path('app/'), 'gitssh');
         file_put_contents($wrapper, $this->gitWrapperScript($this->private_key));
 
-        $workingDir = tempnam(storage_path() . '/app/', 'clone');
+        $workingDir = tempnam(storage_path('app/'), 'clone');
         unlink($workingDir);
 
         $tarFile = $this->release_archive;

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -82,7 +82,12 @@ class DeployProject extends Job implements ShouldQueue
         $this->private_key = tempnam(storage_path('app/'), 'sshkey');
         file_put_contents($this->private_key, $project->private_key);
 
-        $this->release_archive = storage_path('app/') . $this->deployment->project_id . '_' . $this->release_id . '.tar.gz';
+        $this->release_archive = sprintf(
+            '%s/%d_%s.tar.gz',
+            storage_path('app'),
+            $this->deployment->project_id,
+            $this->release_id
+        );
 
         try {
             $this->updateRepoInfo();

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -2,7 +2,6 @@
 
 namespace REBELinBLUE\Deployer\Jobs;
 
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Queue\InteractsWithQueue;

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -89,8 +89,13 @@ class DeployProject extends Job implements ShouldQueue
             $this->release_id
         );
 
+        $this->dispatch(new UpdateGitMirror($this->deployment->project));
+
         try {
-            $this->updateRepoInfo();
+            // If the build has been manually triggered get the committer info from the repo
+            if ($this->deployment->commit === Deployment::LOADING) {
+                $this->updateRepoInfo();
+            }
 
             $this->createReleaseArchive();
 
@@ -145,8 +150,6 @@ class DeployProject extends Job implements ShouldQueue
      */
     private function updateRepoInfo()
     {
-        $this->dispatch(new UpdateGitMirror($this->deployment->project));
-
         $process = new Process(sprintf(
             'cd %s && git log %s -n1 --pretty=format:"%%H%%x09%%an%%x09%%ae"',
             $this->deployment->project->mirrorPath(),

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -590,20 +590,20 @@ OUT;
     /**
      * Send a string to server.
      *
-     * @param  Server $server   target server
-     * @param  string $filename remote filename
-     * @param  string $content  the file content
+     * @param  Server $server      target server
+     * @param  string $remote_path remote filename
+     * @param  string $content     the file content
      * @return void
      */
-    private function sendFileFromString(Server $server, $filepath, $content)
+    private function sendFileFromString(Server $server, $remote_path, $content)
     {
-        $wrapper = tempnam(storage_path() . '/app/', 'tmpfile');
-        file_put_contents($wrapper, $content);
+        $tmp_file = tempnam(storage_path('app/'), 'tmpfile');
+        file_put_contents($tmp_file, $content);
 
         // Upload the wrapper file
-        $this->sendFile($wrapper, $filepath, $server);
+        $this->sendFile($tmp_file, $remote_path, $server);
 
-        unlink($wrapper);
+        unlink($tmp_file);
     }
 
     /**

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -588,30 +588,6 @@ OUT;
     }
 
     /**
-     * Prepares a server for code deployment by adding the files which are required.
-     *
-     * @param  Server $server
-     * @return void
-     */
-    private function prepareServer(Server $server)
-    {
-        $root_dir = preg_replace('#/$#', '', $server->path);
-
-        $remote_key_file     = $root_dir . '/id_rsa';
-        $remote_wrapper_file = $root_dir . '/wrapper.sh';
-
-        // Upload the SSH private key
-        $this->sendFile($this->private_key, $remote_key_file, $server);
-
-        // Upload the wrapper file
-        $this->sendFileFromString(
-            $server,
-            $remote_wrapper_file,
-            $this->gitWrapperScript($remote_key_file)
-        );
-    }
-
-    /**
      * Send a string to server.
      *
      * @param  Server $server   target server

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -181,11 +181,11 @@ CMD;
 
         $git_info = $process->getOutput();
 
-        $parts = explode("\x09", $git_info);
+        list($commit, $committer, $email) = explode("\x09", $git_info);
 
-        $this->deployment->commit          = $parts[0];
-        $this->deployment->committer       = trim($parts[1]);
-        $this->deployment->committer_email = trim($parts[2]);
+        $this->deployment->commit          = $commit;
+        $this->deployment->committer       = trim($committer);
+        $this->deployment->committer_email = trim($email);
 
         if (!$this->deployment->user_id && !$this->deployment->source) {
             $user = User::where('email', $this->deployment->committer_email)->first();
@@ -201,7 +201,7 @@ CMD;
 export GIT_DIR="{$working_dir}/.git" && \
 export GIT_WORK_TREE="{$working_dir}" && \
 cd {$working_dir} && \
-(git archive --format=tar HEAD | gzip > {$tar_file}) && \
+(git archive --format=tar {$commit} | gzip > {$tar_file}) && \
 rm -rf {$working_dir}
 CMD;
 

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -4,6 +4,7 @@ namespace REBELinBLUE\Deployer\Jobs;
 
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Queue;
 use Illuminate\Queue\SerializesModels;

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -463,7 +463,7 @@ CMD;
             }
 
             $tokens = [
-                '{{ release }}'         => $release_id,
+                '{{ release }}'         => $this->release_id,
                 '{{ release_path }}'    => $latest_release_dir,
                 '{{ project_path }}'    => $root_dir,
                 '{{ branch }}'          => $this->deployment->branch,

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -198,7 +198,7 @@ CMD;
     }
 
     /**
-     * Removed left over artifacts from a failed deploy on each server.
+     * Remove left over artifacts from a failed deploy on each server.
      *
      * @return void
      */
@@ -267,6 +267,7 @@ CMD;
 
             try {
                 $server = $log->server;
+                // FIME: Have a getFiles method here for transferring files
                 $script = $this->getScript($step, $server);
 
                 $user = $server->user;

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -144,21 +144,21 @@ class DeployProject extends Job implements ShouldQueue
     {
         $this->dispatch(new UpdateGitMirror($this->deployment->project));
 
-        $mirrorDir = $this->deployment->project->mirrorPath();
+        $mirror_dir = $this->deployment->project->mirrorPath();
 
         $wrapper = tempnam(storage_path('app/'), 'gitssh');
         file_put_contents($wrapper, $this->gitWrapperScript($this->private_key));
 
-        $workingDir = tempnam(storage_path('app/'), 'clone');
-        unlink($workingDir);
+        $working_dir = tempnam(storage_path('app/'), 'clone');
+        unlink($working_dir);
 
-        $tarFile = $this->release_archive;
+        $tar_file = $this->release_archive;
 
         $cmd = <<< CMD
 chmod +x "{$wrapper}" && \
 export GIT_SSH="{$wrapper}" && \
-git clone --recursive --quiet --reference {$mirrorDir} --branch %s --depth 1 %s {$workingDir} && \
-cd {$workingDir} && \
+git clone --recursive --quiet --reference {$mirror_dir} --branch %s --depth 1 %s {$working_dir} && \
+cd {$working_dir} && \
 git checkout %s --quiet && \
 git log --pretty=format:"%%H%%x09%%an%%x09%%ae"
 CMD;
@@ -198,11 +198,11 @@ CMD;
         $this->deployment->save();
 
         $cmd = <<< CMD
-export GIT_DIR="{$workingDir}/.git" && \
-export GIT_WORK_TREE="{$workingDir}" && \
-cd {$workingDir} && \
-(git archive --format=tar HEAD | gzip > {$tarFile}) && \
-rm -rf {$workingDir}
+export GIT_DIR="{$working_dir}/.git" && \
+export GIT_WORK_TREE="{$working_dir}" && \
+cd {$working_dir} && \
+(git archive --format=tar HEAD | gzip > {$tar_file}) && \
+rm -rf {$working_dir}
 CMD;
 
         $process = new Process($cmd);

--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -220,15 +220,9 @@ CMD;
             $releases_dir       = $root_dir . '/releases';
             $latest_release_dir = $releases_dir . '/' . $this->release_id;
 
-            // $remote_key_file     = $root_dir . '/id_rsa';
-            // $remote_wrapper_file = $root_dir . '/wrapper.sh';
-            //
-            // FIXME: Delete tar file if it exists
-
             $commands = [
                 sprintf('cd %s', $root_dir),
-                //sprintf('[ -f %s ] && rm %s', $remote_key_file, $remote_key_file),
-                //sprintf('[ -f %s ] && rm %s', $remote_wrapper_file, $remote_wrapper_file),
+                sprintf('[ -f %s ] && rm %s', $this->remote_archive, $this->remote_archive),
                 sprintf('[ -d %s ] && rm -rf %s', $latest_release_dir, $latest_release_dir),
             ];
 

--- a/app/Jobs/RequestProjectCheckUrl.php
+++ b/app/Jobs/RequestProjectCheckUrl.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\DB;
 use REBELinBLUE\Deployer\Jobs\Job;
 
 /**

--- a/app/Jobs/TestServerConnection.php
+++ b/app/Jobs/TestServerConnection.php
@@ -40,7 +40,7 @@ class TestServerConnection extends Job implements ShouldQueue
         $this->server->status = Server::TESTING;
         $this->server->save();
 
-        $key = tempnam(storage_path() . '/app/', 'sshkey');
+        $key = tempnam(storage_path('app/'), 'sshkey');
         file_put_contents($key, $this->server->project->private_key);
 
         try {

--- a/app/Jobs/UpdateGitMirror.php
+++ b/app/Jobs/UpdateGitMirror.php
@@ -12,7 +12,7 @@ use REBELinBLUE\Deployer\Project;
 use Symfony\Component\Process\Process;
 
 /**
- * Updates the git mirror for a project
+ * Updates the git mirror for a project.
  */
 class UpdateGitMirror extends Job implements SelfHandling
 {

--- a/app/Jobs/UpdateGitMirror.php
+++ b/app/Jobs/UpdateGitMirror.php
@@ -48,7 +48,6 @@ class UpdateGitMirror extends Job implements SelfHandling
         file_put_contents($wrapper, $this->gitWrapperScript($private_key));
 
         $cmd = <<< CMD
-set -e && \
 chmod +x "{$wrapper}" && \
 export GIT_SSH="{$wrapper}" && \
 ( [ ! -d {$mirror_dir} ] && git clone --mirror %s {$mirror_dir} || cd . ) && \

--- a/app/Jobs/UpdateGitMirror.php
+++ b/app/Jobs/UpdateGitMirror.php
@@ -2,13 +2,13 @@
 
 namespace REBELinBLUE\Deployer\Jobs;
 
-use REBELinBLUE\Deployer\Jobs\Job;
-use REBELinBLUE\Deployer\Project;
-use Illuminate\Foundation\Bus\DispatchesJobs;
-use REBELinBLUE\Deployer\Jobs\UpdateGitReferences;
 use Illuminate\Contracts\Bus\SelfHandling;
+use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use REBELinBLUE\Deployer\Jobs\Job;
+use REBELinBLUE\Deployer\Jobs\UpdateGitReferences;
+use REBELinBLUE\Deployer\Project;
 use Symfony\Component\Process\Process;
 
 class UpdateGitMirror extends Job implements SelfHandling

--- a/app/Jobs/UpdateGitMirror.php
+++ b/app/Jobs/UpdateGitMirror.php
@@ -39,7 +39,7 @@ class UpdateGitMirror extends Job implements SelfHandling
     {
         // Use the repository rather than the project ID, so if a single
         // repo is used in multiple projects it is not duplicated
-        $mirrorDir = $this->project->mirrorPath();
+        $mirror_dir = $this->project->mirrorPath();
 
         $private_key = tempnam(storage_path('app/'), 'sshkey');
         file_put_contents($private_key, $this->project->private_key);
@@ -51,8 +51,8 @@ class UpdateGitMirror extends Job implements SelfHandling
 set -e && \
 chmod +x "{$wrapper}" && \
 export GIT_SSH="{$wrapper}" && \
-( [ ! -d {$mirrorDir} ] && git clone --mirror %s {$mirrorDir} || cd . ) && \
-cd {$mirrorDir} && \
+( [ ! -d {$mirror_dir} ] && git clone --mirror %s {$mirror_dir} || cd . ) && \
+cd {$mirror_dir} && \
 git fetch --all --prune
 CMD;
 

--- a/app/Jobs/UpdateGitMirror.php
+++ b/app/Jobs/UpdateGitMirror.php
@@ -48,12 +48,12 @@ class UpdateGitMirror extends Job implements SelfHandling
         file_put_contents($wrapper, $this->gitWrapperScript($private_key));
 
         $cmd = <<< CMD
+set -e && \
 chmod +x "{$wrapper}" && \
 export GIT_SSH="{$wrapper}" && \
-( [ ! -d {$mirrorDir} ] && git clone --mirror %s {$mirrorDir} ) && \
-cd {$mirrorDir} &&
+( [ ! -d {$mirrorDir} ] && git clone --mirror %s {$mirrorDir} || cd . ) && \
+cd {$mirrorDir} && \
 git fetch --all --prune
-exit 0 # FIXME: Not sure why I need this, otherwise it fails
 CMD;
 
         $process = new Process(sprintf($cmd, $this->project->repository));

--- a/app/Jobs/UpdateGitMirror.php
+++ b/app/Jobs/UpdateGitMirror.php
@@ -11,6 +11,9 @@ use REBELinBLUE\Deployer\Jobs\UpdateGitReferences;
 use REBELinBLUE\Deployer\Project;
 use Symfony\Component\Process\Process;
 
+/**
+ * Updates the git mirror for a project
+ */
 class UpdateGitMirror extends Job implements SelfHandling
 {
     use InteractsWithQueue, SerializesModels, DispatchesJobs;

--- a/app/Jobs/UpdateGitMirror.php
+++ b/app/Jobs/UpdateGitMirror.php
@@ -67,6 +67,9 @@ CMD;
             throw new \RuntimeException('Could not mirror repository - ' . $process->getErrorOutput());
         }
 
+        $this->project->last_mirrored = date('Y-m-d H:i:s');
+        $this->project->save();
+
         $this->dispatch(new UpdateGitReferences($this->project));
     }
 

--- a/app/Jobs/UpdateGitReferences.php
+++ b/app/Jobs/UpdateGitReferences.php
@@ -38,12 +38,12 @@ class UpdateGitReferences extends Job implements SelfHandling, ShouldQueue
      */
     public function handle()
     {
-        $mirrorDir = $this->project->mirrorPath();
+        $mirror_dir = $this->project->mirrorPath();
 
         $this->project->refs()->delete();
 
         foreach (['tag', 'branch'] as $ref) {
-            $process = new Process("cd {$mirrorDir} && git {$ref} --list --no-column");
+            $process = new Process("cd {$mirror_dir} && git {$ref} --list --no-column");
             $process->setTimeout(null);
             $process->run();
 

--- a/app/Presenters/DeploymentPresenter.php
+++ b/app/Presenters/DeploymentPresenter.php
@@ -56,6 +56,24 @@ class DeploymentPresenter extends Presenter
     }
 
     /**
+     * Gets the IDs of the optional commands which were included in the deployments, for use in a data attribute.
+     *
+     * @return string
+     */
+    public function presentOptionalCommandsUsed()
+    {
+        $commands = [];
+
+        foreach ($this->object->commands as $command)
+        {
+            $commands[] = $command->id;
+        }
+
+
+        return implode(',', $commands);
+    }
+
+    /**
      * Gets the CSS icon class for the deployment status.
      *
      * @return string

--- a/app/Presenters/DeploymentPresenter.php
+++ b/app/Presenters/DeploymentPresenter.php
@@ -62,9 +62,12 @@ class DeploymentPresenter extends Presenter
      */
     public function presentIcon()
     {
+        $finished_statuses = [Deployment::FAILED, Deployment::COMPLETED_WITH_ERRORS,
+                              Deployment::ABORTING, Deployment::ABORTED, ];
+
         if ($this->status === Deployment::COMPLETED) {
             return 'check';
-        } elseif (in_array($this->status, [Deployment::FAILED, Deployment::COMPLETED_WITH_ERRORS, Deployment::ABORTING, Deployment::ABORTED], true)) {
+        } elseif (in_array($this->status, $finished_statuses, true)) {
             return 'warning';
         } elseif ($this->status === Deployment::DEPLOYING) {
             return 'spinner fa-pulse';

--- a/app/Presenters/DeploymentPresenter.php
+++ b/app/Presenters/DeploymentPresenter.php
@@ -64,9 +64,10 @@ class DeploymentPresenter extends Presenter
     {
         $commands = [];
 
-        foreach ($this->object->commands as $command)
-        {
-            $commands[] = $command->id;
+        foreach ($this->object->commands as $command) {
+            if ($command->optional) {
+                $commands[] = $command->id;
+            }
         }
 
 

--- a/app/Presenters/DeploymentPresenter.php
+++ b/app/Presenters/DeploymentPresenter.php
@@ -70,7 +70,6 @@ class DeploymentPresenter extends Presenter
             }
         }
 
-
         return implode(',', $commands);
     }
 

--- a/app/Project.php
+++ b/app/Project.php
@@ -350,7 +350,7 @@ class Project extends ProjectRelation implements PresentableInterface
     /**
      * Generate a friendly path for the mirror of the repository.
      * Use the repository rather than the project ID, so if a single
-     * repo is used in multiple projects it is not duplicated
+     * repo is used in multiple projects it is not duplicated.
      *
      * @return string
      */

--- a/app/Project.php
+++ b/app/Project.php
@@ -356,6 +356,6 @@ class Project extends ProjectRelation implements PresentableInterface
      */
     public function mirrorPath()
     {
-        return storage_path('app/' . preg_replace('/[^_\-.\-a-zA-Z0-9\s]/u', '_', $this->repository));
+        return storage_path('app/mirrors/' . preg_replace('/[^_\-.\-a-zA-Z0-9\s]/u', '_', $this->repository));
     }
 }

--- a/app/Project.php
+++ b/app/Project.php
@@ -31,7 +31,7 @@ class Project extends ProjectRelation implements PresentableInterface
                          'updated_at', 'servers', 'commands', 'hash', 'notifyEmails',
                          'group', 'servers', 'commands', 'heartbeats', 'checkUrls',
                          'notifications', 'deployments', 'shareFiles', 'projectFiles',
-                         'is_template', ];
+                         'is_template', 'last_mirrored', ];
 
     /**
      * The attributes that are mass assignable.
@@ -46,7 +46,7 @@ class Project extends ProjectRelation implements PresentableInterface
      *
      * @var array
      */
-    protected $dates = ['last_run'];
+    protected $dates = ['last_run', 'last_mirrored'];
 
     /**
      * Additional attributes to include in the JSON representation.

--- a/app/Project.php
+++ b/app/Project.php
@@ -8,6 +8,7 @@ use REBELinBLUE\Deployer\Presenters\ProjectPresenter;
 use REBELinBLUE\Deployer\Traits\BroadcastChanges;
 use Robbo\Presenter\PresentableInterface;
 use Symfony\Component\Process\Process;
+use Version\Compare as VersionCompare;
 
 /**
  * Project model.
@@ -322,13 +323,13 @@ class Project extends ProjectRelation implements PresentableInterface
      */
     public function tags()
     {
-        // FIXME: There has to be a way to do this without converting to an array and then back to a collection
         $tags = $this->refs()
                      ->where('is_tag', true)
                      ->lists('name')
                      ->toArray();
 
-        usort($tags, 'version_compare'); // FIXME: Change this to use the Version\Version library!
+        $compare = new VersionCompare;
+        usort($tags, array($compare, 'compare'));
 
         return collect($tags);
     }

--- a/app/Project.php
+++ b/app/Project.php
@@ -329,7 +329,7 @@ class Project extends ProjectRelation implements PresentableInterface
                      ->toArray();
 
         $compare = new VersionCompare;
-        usort($tags, array($compare, 'compare'));
+        usort($tags, [$compare, 'compare']);
 
         return collect($tags);
     }

--- a/app/Project.php
+++ b/app/Project.php
@@ -328,7 +328,7 @@ class Project extends ProjectRelation implements PresentableInterface
                      ->lists('name')
                      ->toArray();
 
-        usort($tags, 'version_compare');
+        usort($tags, 'version_compare'); // FIXME: Change this to use the Version\Version library!
 
         return collect($tags);
     }

--- a/app/ProjectRelation.php
+++ b/app/ProjectRelation.php
@@ -134,6 +134,6 @@ abstract class ProjectRelation extends Model
      */
     public function refs()
     {
-        return $this->hasMany('REBELinBLUE\Deployer\Ref');
+        return $this->hasMany(Ref::class);
     }
 }

--- a/app/Repositories/Contracts/DeploymentRepositoryInterface.php
+++ b/app/Repositories/Contracts/DeploymentRepositoryInterface.php
@@ -7,6 +7,7 @@ interface DeploymentRepositoryInterface
     public function create(array $fields);
     public function getById($model_id);
     public function abort($model_id);
+    public function rollback($model_id);
     public function getLatest($project_id, $paginate = 15);
     public function getLatestSuccessful($project_id);
     public function getTimeline();

--- a/app/Repositories/Contracts/DeploymentRepositoryInterface.php
+++ b/app/Repositories/Contracts/DeploymentRepositoryInterface.php
@@ -7,7 +7,7 @@ interface DeploymentRepositoryInterface
     public function create(array $fields);
     public function getById($model_id);
     public function abort($model_id);
-    public function rollback($model_id);
+    public function rollback($model_id, array $optional = []);
     public function getLatest($project_id, $paginate = 15);
     public function getLatestSuccessful($project_id);
     public function getTimeline();

--- a/app/Repositories/EloquentDeploymentRepository.php
+++ b/app/Repositories/EloquentDeploymentRepository.php
@@ -75,7 +75,7 @@ class EloquentDeploymentRepository extends EloquentRepository implements Deploym
     /**
      * Creates a new deployment based on a previous one.
      *
-     * @param  int  $model_id
+     * @param  int   $model_id
      * @param  array $optional
      * @return void
      */

--- a/app/Repositories/EloquentDeploymentRepository.php
+++ b/app/Repositories/EloquentDeploymentRepository.php
@@ -73,6 +73,34 @@ class EloquentDeploymentRepository extends EloquentRepository implements Deploym
     }
 
     /**
+     * Creates a new deployment based on a previous one.
+     *
+     * @param  int  $model_id
+     * @return void
+     */
+    public function rollback($model_id)
+    {
+        $previous = $this->getById($model_id);
+
+        $deployment = $this->model->create([
+            'committer'       => $previous->committer,
+            'committer_email' => $previous->committer_email,
+            'commit'          => $previous->commit,
+            'project_id'      => $previous->project_id,
+            'branch'          => $previous->branch,
+            'project_id'      => $previous->project_id,
+        ]);
+
+        $this->dispatch(new QueueDeployment(
+            $deployment->project,
+            $deployment,
+            []
+        ));
+
+        return $deployment;
+    }
+
+    /**
      * Gets the latest deployments for a project.
      *
      * @param  int   $project_id

--- a/app/Repositories/EloquentDeploymentRepository.php
+++ b/app/Repositories/EloquentDeploymentRepository.php
@@ -76,28 +76,22 @@ class EloquentDeploymentRepository extends EloquentRepository implements Deploym
      * Creates a new deployment based on a previous one.
      *
      * @param  int  $model_id
+     * @param  array $optional
      * @return void
      */
-    public function rollback($model_id)
+    public function rollback($model_id, array $optional = [])
     {
         $previous = $this->getById($model_id);
 
-        $deployment = $this->model->create([
+        return $this->create([
             'committer'       => $previous->committer,
             'committer_email' => $previous->committer_email,
             'commit'          => $previous->commit,
             'project_id'      => $previous->project_id,
             'branch'          => $previous->branch,
             'project_id'      => $previous->project_id,
+            'optional'        => $optional,
         ]);
-
-        $this->dispatch(new QueueDeployment(
-            $deployment->project,
-            $deployment,
-            []
-        ));
-
-        return $deployment;
     }
 
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -231,6 +231,7 @@
         },
         {
             "name": "barryvdh/laravel-ide-helper",
+<<<<<<< HEAD
             "version": "v2.1.3",
             "source": {
                 "type": "git",
@@ -241,6 +242,18 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/19553f63e4635480363ff2254350075f285fbbc5",
                 "reference": "19553f63e4635480363ff2254350075f285fbbc5",
+=======
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-ide-helper.git",
+                "reference": "d82e8f191fb043a0f8cbf2de64fd3027bfa4f772"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/d82e8f191fb043a0f8cbf2de64fd3027bfa4f772",
+                "reference": "d82e8f191fb043a0f8cbf2de64fd3027bfa4f772",
+>>>>>>> Added IDE helper
                 "shasum": ""
             },
             "require": {
@@ -248,8 +261,13 @@
                 "illuminate/filesystem": "5.0.x|5.1.x|5.2.x",
                 "illuminate/support": "5.0.x|5.1.x|5.2.x",
                 "php": ">=5.4.0",
+<<<<<<< HEAD
                 "phpdocumentor/reflection-docblock": "^2.0.4",
                 "symfony/class-loader": "~2.3|~3.0"
+=======
+                "phpdocumentor/reflection-docblock": "2.0.4",
+                "symfony/class-loader": "~2.3"
+>>>>>>> Added IDE helper
             },
             "require-dev": {
                 "doctrine/dbal": "~2.3"
@@ -290,7 +308,11 @@
                 "phpstorm",
                 "sublime"
             ],
+<<<<<<< HEAD
             "time": "2016-03-02 10:03:09"
+=======
+            "time": "2015-12-21 19:48:06"
+>>>>>>> Added IDE helper
         },
         {
             "name": "christian-riesen/base32",
@@ -1444,8 +1466,11 @@
         {
             "name": "laravel/framework",
 <<<<<<< HEAD
+<<<<<<< HEAD
             "version": "v5.2.22",
 =======
+=======
+>>>>>>> Added IDE helper
 <<<<<<< HEAD
             "version": "v5.2.20",
 >>>>>>> Updated dependencies
@@ -1464,17 +1489,28 @@
                 "reference": "d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
 =======
             "version": "v5.2.16",
+=======
+            "version": "v5.2.20",
+>>>>>>> Added IDE helper
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "39e89553c124dce266da03ee3c0260bdd62f1848"
+                "reference": "d4ff9a1e3e9b2f99f8f3e957876e343d804d944f"
             },
             "dist": {
                 "type": "zip",
+<<<<<<< HEAD
                 "url": "https://api.github.com/repos/laravel/framework/zipball/39e89553c124dce266da03ee3c0260bdd62f1848",
                 "reference": "39e89553c124dce266da03ee3c0260bdd62f1848",
 >>>>>>> Updated dependencies
+<<<<<<< HEAD
 >>>>>>> Updated dependencies
+=======
+=======
+                "url": "https://api.github.com/repos/laravel/framework/zipball/d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
+                "reference": "d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
+>>>>>>> Added IDE helper
+>>>>>>> Added IDE helper
                 "shasum": ""
             },
             "require": {
@@ -1590,14 +1626,23 @@
                 "laravel"
             ],
 <<<<<<< HEAD
+<<<<<<< HEAD
             "time": "2016-02-27 22:09:19"
 =======
+=======
+>>>>>>> Added IDE helper
 <<<<<<< HEAD
             "time": "2016-02-19 17:58:28"
 =======
             "time": "2016-02-15 17:46:58"
 >>>>>>> Updated dependencies
+<<<<<<< HEAD
 >>>>>>> Updated dependencies
+=======
+=======
+            "time": "2016-02-19 17:58:28"
+>>>>>>> Added IDE helper
+>>>>>>> Added IDE helper
         },
         {
             "name": "league/flysystem",
@@ -2712,6 +2757,7 @@
         },
         {
             "name": "symfony/class-loader",
+<<<<<<< HEAD
             "version": "v3.0.3",
             "source": {
                 "type": "git",
@@ -2733,11 +2779,34 @@
             },
             "suggest": {
                 "symfony/polyfill-apcu": "For using ApcClassLoader on HHVM"
+=======
+            "version": "v2.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/class-loader.git",
+                "reference": "98e9089a428ed0e39423b67352c57ef5910a3269"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/class-loader/zipball/98e9089a428ed0e39423b67352c57ef5910a3269",
+                "reference": "98e9089a428ed0e39423b67352c57ef5910a3269",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/finder": "~2.0,>=2.0.5|~3.0.0"
+>>>>>>> Added IDE helper
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
+<<<<<<< HEAD
                     "dev-master": "3.0-dev"
+=======
+                    "dev-master": "2.8-dev"
+>>>>>>> Added IDE helper
                 }
             },
             "autoload": {
@@ -2764,7 +2833,11 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
+<<<<<<< HEAD
             "time": "2016-02-03 09:33:23"
+=======
+            "time": "2016-01-03 15:33:41"
+>>>>>>> Added IDE helper
         },
         {
             "name": "symfony/console",
@@ -4305,7 +4378,11 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
+<<<<<<< HEAD
             "time": "2016-02-23 08:20:26"
+=======
+            "time": "2015-10-16 08:49:58"
+>>>>>>> Added IDE helper
         },
         {
             "name": "phploc/phploc",

--- a/composer.lock
+++ b/composer.lock
@@ -246,7 +246,8 @@
             "require": {
                 "illuminate/console": "5.0.x|5.1.x|5.2.x",
                 "illuminate/filesystem": "5.0.x|5.1.x|5.2.x",
-                "illuminate/support": "5.0.x|5
+                "illuminate/support": "5.0.x|5.1.x|5.2.x",
+                "php": ">=5.4.0",
                 "phpdocumentor/reflection-docblock": "^2.0.4",
                 "symfony/class-loader": "~2.3|~3.0"
             },
@@ -1442,19 +1443,7 @@
         },
         {
             "name": "laravel/framework",
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
             "version": "v5.2.22",
-=======
-=======
->>>>>>> Added IDE helper
-<<<<<<< HEAD
-=======
->>>>>>> Updated
-            "version": "v5.2.20",
->>>>>>> Updated dependencies
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
@@ -1462,47 +1451,8 @@
             },
             "dist": {
                 "type": "zip",
-<<<<<<< HEAD
                 "url": "https://api.github.com/repos/laravel/framework/zipball/aec1b7cb9ec0bac0107361a3730cac9b6f945ef4",
                 "reference": "aec1b7cb9ec0bac0107361a3730cac9b6f945ef4",
-=======
-                "url": "https://api.github.com/repos/laravel/framework/zipball/d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
-                "reference": "d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
-<<<<<<< HEAD
-=======
-            "version": "v5.2.16",
-=======
-            "version": "v5.2.20",
->>>>>>> Added IDE helper
-=======
-            "version": "v5.2.21",
->>>>>>> Added a method to load the commands used in a deployment
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/framework.git",
-                "reference": "4df24638165650a833e072851cad39606da89faf"
-            },
-            "dist": {
-                "type": "zip",
-<<<<<<< HEAD
-<<<<<<< HEAD
-                "url": "https://api.github.com/repos/laravel/framework/zipball/39e89553c124dce266da03ee3c0260bdd62f1848",
-                "reference": "39e89553c124dce266da03ee3c0260bdd62f1848",
->>>>>>> Updated dependencies
-<<<<<<< HEAD
->>>>>>> Updated dependencies
-=======
-=======
-                "url": "https://api.github.com/repos/laravel/framework/zipball/d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
-                "reference": "d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
->>>>>>> Added IDE helper
->>>>>>> Added IDE helper
-=======
->>>>>>> Updated
-=======
-                "url": "https://api.github.com/repos/laravel/framework/zipball/4df24638165650a833e072851cad39606da89faf",
-                "reference": "4df24638165650a833e072851cad39606da89faf",
->>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
@@ -1617,32 +1567,7 @@
                 "framework",
                 "laravel"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
             "time": "2016-02-27 22:09:19"
-=======
-=======
->>>>>>> Added IDE helper
-<<<<<<< HEAD
-            "time": "2016-02-19 17:58:28"
-=======
-            "time": "2016-02-15 17:46:58"
->>>>>>> Updated dependencies
-<<<<<<< HEAD
->>>>>>> Updated dependencies
-=======
-=======
-            "time": "2016-02-19 17:58:28"
->>>>>>> Added IDE helper
->>>>>>> Added IDE helper
-=======
-            "time": "2016-02-19 17:58:28"
->>>>>>> Updated
-=======
-            "time": "2016-02-24 15:13:36"
->>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "league/flysystem",
@@ -2530,7 +2455,6 @@
         },
         {
             "name": "psy/psysh",
-<<<<<<< HEAD
             "version": "v0.7.1",
             "source": {
                 "type": "git",
@@ -2541,18 +2465,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/bobthecow/psysh/zipball/5e8cedbe0a3681f18782594eefc78423f8401fc8",
                 "reference": "5e8cedbe0a3681f18782594eefc78423f8401fc8",
-=======
-            "version": "v0.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "1573b36948a32bdaf43db525edf5e95d5a08ed06"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/1573b36948a32bdaf43db525edf5e95d5a08ed06",
-                "reference": "1573b36948a32bdaf43db525edf5e95d5a08ed06",
->>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
@@ -2611,11 +2523,7 @@
                 "interactive",
                 "shell"
             ],
-<<<<<<< HEAD
             "time": "2016-02-27 18:59:18"
-=======
-            "time": "2016-02-20 16:27:05"
->>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "robclancy/presenter",
@@ -2774,7 +2682,6 @@
         },
         {
             "name": "symfony/class-loader",
-<<<<<<< HEAD
             "version": "v3.0.3",
             "source": {
                 "type": "git",
@@ -2796,34 +2703,11 @@
             },
             "suggest": {
                 "symfony/polyfill-apcu": "For using ApcClassLoader on HHVM"
-=======
-            "version": "v2.8.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/class-loader.git",
-                "reference": "98e9089a428ed0e39423b67352c57ef5910a3269"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/98e9089a428ed0e39423b67352c57ef5910a3269",
-                "reference": "98e9089a428ed0e39423b67352c57ef5910a3269",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "symfony/finder": "~2.0,>=2.0.5|~3.0.0"
->>>>>>> Added IDE helper
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-<<<<<<< HEAD
                     "dev-master": "3.0-dev"
-=======
-                    "dev-master": "2.8-dev"
->>>>>>> Added IDE helper
                 }
             },
             "autoload": {
@@ -2850,11 +2734,7 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-<<<<<<< HEAD
             "time": "2016-02-03 09:33:23"
-=======
-            "time": "2016-01-03 15:33:41"
->>>>>>> Added IDE helper
         },
         {
             "name": "symfony/console",
@@ -4365,15 +4245,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-<<<<<<< HEAD
-<<<<<<< HEAD
             "time": "2016-02-23 08:20:26"
-=======
-            "time": "2015-10-16 08:49:58"
->>>>>>> Added IDE helper
-=======
-            "time": "2016-02-23 08:20:26"
->>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "phploc/phploc",
@@ -5576,7 +5448,6 @@
         },
         {
             "name": "symfony/config",
-<<<<<<< HEAD
             "version": "v3.0.3",
             "source": {
                 "type": "git",
@@ -5587,29 +5458,14 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/symfony/config/zipball/79a97025f7bf4bbf8352b5df1905aa136a531066",
                 "reference": "79a97025f7bf4bbf8352b5df1905aa136a531066",
-=======
-            "version": "v3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/config.git",
-                "reference": "8c83ff9a2ffbed1e606bc816db11ddc2385a16ee"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/8c83ff9a2ffbed1e606bc816db11ddc2385a16ee",
-                "reference": "8c83ff9a2ffbed1e606bc816db11ddc2385a16ee",
->>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
                 "symfony/filesystem": "~2.8|~3.0"
-<<<<<<< HEAD
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
-=======
->>>>>>> Added a method to load the commands used in a deployment
             },
             "type": "library",
             "extra": {
@@ -5641,11 +5497,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-<<<<<<< HEAD
             "time": "2016-02-23 15:16:06"
-=======
-            "time": "2016-01-21 09:38:31"
->>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "symfony/css-selector",
@@ -5702,7 +5554,6 @@
         },
         {
             "name": "symfony/dependency-injection",
-<<<<<<< HEAD
             "version": "v3.0.3",
             "source": {
                 "type": "git",
@@ -5713,18 +5564,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/821800ae6753b88dab55a7280811d8734b8112bf",
                 "reference": "821800ae6753b88dab55a7280811d8734b8112bf",
-=======
-            "version": "v3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "7f2ec173cc0366efa0ca1f6b1255803ed7c17028"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7f2ec173cc0366efa0ca1f6b1255803ed7c17028",
-                "reference": "7f2ec173cc0366efa0ca1f6b1255803ed7c17028",
->>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
@@ -5770,11 +5609,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-<<<<<<< HEAD
             "time": "2016-02-28 16:50:08"
-=======
-            "time": "2016-02-02 13:48:39"
->>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "symfony/dom-crawler",
@@ -5834,7 +5669,6 @@
         },
         {
             "name": "symfony/filesystem",
-<<<<<<< HEAD
             "version": "v3.0.3",
             "source": {
                 "type": "git",
@@ -5845,18 +5679,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/symfony/filesystem/zipball/23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
                 "reference": "23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
-=======
-            "version": "v3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "064ac12afd2ceb8a2c1bfb7bed8e931c6dd1997f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/064ac12afd2ceb8a2c1bfb7bed8e931c6dd1997f",
-                "reference": "064ac12afd2ceb8a2c1bfb7bed8e931c6dd1997f",
->>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
@@ -5892,11 +5714,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-<<<<<<< HEAD
             "time": "2016-02-23 15:16:06"
-=======
-            "time": "2016-01-27 11:34:55"
->>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "symfony/stopwatch",
@@ -6039,17 +5857,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-<<<<<<< HEAD
     "stability-flags": {
-<<<<<<< HEAD
         "andywer/js-localization": 20
-=======
-        "version/version": 20
->>>>>>> Compare tags with version suffixes
     },
-=======
-    "stability-flags": [],
->>>>>>> Updated dependencies
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -231,7 +231,6 @@
         },
         {
             "name": "barryvdh/laravel-ide-helper",
-<<<<<<< HEAD
             "version": "v2.1.3",
             "source": {
                 "type": "git",
@@ -242,32 +241,14 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/19553f63e4635480363ff2254350075f285fbbc5",
                 "reference": "19553f63e4635480363ff2254350075f285fbbc5",
-=======
-            "version": "v2.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/barryvdh/laravel-ide-helper.git",
-                "reference": "d82e8f191fb043a0f8cbf2de64fd3027bfa4f772"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/barryvdh/laravel-ide-helper/zipball/d82e8f191fb043a0f8cbf2de64fd3027bfa4f772",
-                "reference": "d82e8f191fb043a0f8cbf2de64fd3027bfa4f772",
->>>>>>> Added IDE helper
                 "shasum": ""
             },
             "require": {
                 "illuminate/console": "5.0.x|5.1.x|5.2.x",
                 "illuminate/filesystem": "5.0.x|5.1.x|5.2.x",
-                "illuminate/support": "5.0.x|5.1.x|5.2.x",
-                "php": ">=5.4.0",
-<<<<<<< HEAD
+                "illuminate/support": "5.0.x|5
                 "phpdocumentor/reflection-docblock": "^2.0.4",
                 "symfony/class-loader": "~2.3|~3.0"
-=======
-                "phpdocumentor/reflection-docblock": "2.0.4",
-                "symfony/class-loader": "~2.3"
->>>>>>> Added IDE helper
             },
             "require-dev": {
                 "doctrine/dbal": "~2.3"
@@ -308,11 +289,7 @@
                 "phpstorm",
                 "sublime"
             ],
-<<<<<<< HEAD
             "time": "2016-03-02 10:03:09"
-=======
-            "time": "2015-12-21 19:48:06"
->>>>>>> Added IDE helper
         },
         {
             "name": "christian-riesen/base32",
@@ -1468,6 +1445,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
             "version": "v5.2.22",
 =======
 =======
@@ -1496,13 +1474,17 @@
 =======
             "version": "v5.2.20",
 >>>>>>> Added IDE helper
+=======
+            "version": "v5.2.21",
+>>>>>>> Added a method to load the commands used in a deployment
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "d4ff9a1e3e9b2f99f8f3e957876e343d804d944f"
+                "reference": "4df24638165650a833e072851cad39606da89faf"
             },
             "dist": {
                 "type": "zip",
+<<<<<<< HEAD
 <<<<<<< HEAD
                 "url": "https://api.github.com/repos/laravel/framework/zipball/39e89553c124dce266da03ee3c0260bdd62f1848",
                 "reference": "39e89553c124dce266da03ee3c0260bdd62f1848",
@@ -1517,6 +1499,10 @@
 >>>>>>> Added IDE helper
 =======
 >>>>>>> Updated
+=======
+                "url": "https://api.github.com/repos/laravel/framework/zipball/4df24638165650a833e072851cad39606da89faf",
+                "reference": "4df24638165650a833e072851cad39606da89faf",
+>>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
@@ -1634,6 +1620,7 @@
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
             "time": "2016-02-27 22:09:19"
 =======
 =======
@@ -1653,6 +1640,9 @@
 =======
             "time": "2016-02-19 17:58:28"
 >>>>>>> Updated
+=======
+            "time": "2016-02-24 15:13:36"
+>>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "league/flysystem",
@@ -2540,6 +2530,7 @@
         },
         {
             "name": "psy/psysh",
+<<<<<<< HEAD
             "version": "v0.7.1",
             "source": {
                 "type": "git",
@@ -2550,6 +2541,18 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/bobthecow/psysh/zipball/5e8cedbe0a3681f18782594eefc78423f8401fc8",
                 "reference": "5e8cedbe0a3681f18782594eefc78423f8401fc8",
+=======
+            "version": "v0.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bobthecow/psysh.git",
+                "reference": "1573b36948a32bdaf43db525edf5e95d5a08ed06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/1573b36948a32bdaf43db525edf5e95d5a08ed06",
+                "reference": "1573b36948a32bdaf43db525edf5e95d5a08ed06",
+>>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
@@ -2608,7 +2611,11 @@
                 "interactive",
                 "shell"
             ],
+<<<<<<< HEAD
             "time": "2016-02-27 18:59:18"
+=======
+            "time": "2016-02-20 16:27:05"
+>>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "robclancy/presenter",
@@ -4359,10 +4366,14 @@
             ],
             "description": "Official version of pdepend to be handled with Composer",
 <<<<<<< HEAD
+<<<<<<< HEAD
             "time": "2016-02-23 08:20:26"
 =======
             "time": "2015-10-16 08:49:58"
 >>>>>>> Added IDE helper
+=======
+            "time": "2016-02-23 08:20:26"
+>>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "phploc/phploc",
@@ -5565,6 +5576,7 @@
         },
         {
             "name": "symfony/config",
+<<<<<<< HEAD
             "version": "v3.0.3",
             "source": {
                 "type": "git",
@@ -5575,14 +5587,29 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/symfony/config/zipball/79a97025f7bf4bbf8352b5df1905aa136a531066",
                 "reference": "79a97025f7bf4bbf8352b5df1905aa136a531066",
+=======
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "8c83ff9a2ffbed1e606bc816db11ddc2385a16ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/8c83ff9a2ffbed1e606bc816db11ddc2385a16ee",
+                "reference": "8c83ff9a2ffbed1e606bc816db11ddc2385a16ee",
+>>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9",
                 "symfony/filesystem": "~2.8|~3.0"
+<<<<<<< HEAD
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
+=======
+>>>>>>> Added a method to load the commands used in a deployment
             },
             "type": "library",
             "extra": {
@@ -5614,7 +5641,11 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
+<<<<<<< HEAD
             "time": "2016-02-23 15:16:06"
+=======
+            "time": "2016-01-21 09:38:31"
+>>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "symfony/css-selector",
@@ -5671,6 +5702,7 @@
         },
         {
             "name": "symfony/dependency-injection",
+<<<<<<< HEAD
             "version": "v3.0.3",
             "source": {
                 "type": "git",
@@ -5681,6 +5713,18 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/821800ae6753b88dab55a7280811d8734b8112bf",
                 "reference": "821800ae6753b88dab55a7280811d8734b8112bf",
+=======
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "7f2ec173cc0366efa0ca1f6b1255803ed7c17028"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7f2ec173cc0366efa0ca1f6b1255803ed7c17028",
+                "reference": "7f2ec173cc0366efa0ca1f6b1255803ed7c17028",
+>>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
@@ -5726,7 +5770,11 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
+<<<<<<< HEAD
             "time": "2016-02-28 16:50:08"
+=======
+            "time": "2016-02-02 13:48:39"
+>>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "symfony/dom-crawler",
@@ -5786,6 +5834,7 @@
         },
         {
             "name": "symfony/filesystem",
+<<<<<<< HEAD
             "version": "v3.0.3",
             "source": {
                 "type": "git",
@@ -5796,6 +5845,18 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/symfony/filesystem/zipball/23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
                 "reference": "23ae8f9648d0a7fe94a47c8e20e5bf37c489a451",
+=======
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "064ac12afd2ceb8a2c1bfb7bed8e931c6dd1997f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/064ac12afd2ceb8a2c1bfb7bed8e931c6dd1997f",
+                "reference": "064ac12afd2ceb8a2c1bfb7bed8e931c6dd1997f",
+>>>>>>> Added a method to load the commands used in a deployment
                 "shasum": ""
             },
             "require": {
@@ -5831,7 +5892,11 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
+<<<<<<< HEAD
             "time": "2016-02-23 15:16:06"
+=======
+            "time": "2016-01-27 11:34:55"
+>>>>>>> Added a method to load the commands used in a deployment
         },
         {
             "name": "symfony/stopwatch",

--- a/composer.lock
+++ b/composer.lock
@@ -3579,6 +3579,7 @@
         },
         {
             "name": "version/version",
+<<<<<<< HEAD
             "version": "2.2",
             "source": {
                 "type": "git",
@@ -3589,6 +3590,18 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-mod/version/zipball/2fc90b9ce281b10efa68ebc90a6b339515aba35f",
                 "reference": "2fc90b9ce281b10efa68ebc90a6b339515aba35f",
+=======
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mod/version.git",
+                "reference": "5a3f17a41b449e25d9f83a4503d02e977ca9ebb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mod/version/zipball/5a3f17a41b449e25d9f83a4503d02e977ca9ebb1",
+                "reference": "5a3f17a41b449e25d9f83a4503d02e977ca9ebb1",
+>>>>>>> Compare tags with version suffixes
                 "shasum": ""
             },
             "require": {
@@ -3621,7 +3634,11 @@
                 "semantic",
                 "version"
             ],
+<<<<<<< HEAD
             "time": "2015-06-07 19:06:40"
+=======
+            "time": "2015-06-07 16:18:01"
+>>>>>>> Compare tags with version suffixes
         },
         {
             "name": "vlucas/phpdotenv",
@@ -5855,10 +5872,21 @@
             "time": "2015-05-27 22:58:02"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "2.2",
+            "alias_normalized": "2.2.0.0",
+            "version": "9999999-dev",
+            "package": "version/version"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
+<<<<<<< HEAD
         "andywer/js-localization": 20
+=======
+        "version/version": 20
+>>>>>>> Compare tags with version suffixes
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -1467,11 +1467,14 @@
             "name": "laravel/framework",
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
             "version": "v5.2.22",
 =======
 =======
 >>>>>>> Added IDE helper
 <<<<<<< HEAD
+=======
+>>>>>>> Updated
             "version": "v5.2.20",
 >>>>>>> Updated dependencies
             "source": {
@@ -1487,6 +1490,7 @@
 =======
                 "url": "https://api.github.com/repos/laravel/framework/zipball/d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
                 "reference": "d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
+<<<<<<< HEAD
 =======
             "version": "v5.2.16",
 =======
@@ -1511,6 +1515,8 @@
                 "reference": "d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
 >>>>>>> Added IDE helper
 >>>>>>> Added IDE helper
+=======
+>>>>>>> Updated
                 "shasum": ""
             },
             "require": {
@@ -1627,6 +1633,7 @@
             ],
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
             "time": "2016-02-27 22:09:19"
 =======
 =======
@@ -1643,6 +1650,9 @@
             "time": "2016-02-19 17:58:28"
 >>>>>>> Added IDE helper
 >>>>>>> Added IDE helper
+=======
+            "time": "2016-02-19 17:58:28"
+>>>>>>> Updated
         },
         {
             "name": "league/flysystem",
@@ -3682,8 +3692,6 @@
         },
         {
             "name": "version/version",
-<<<<<<< HEAD
-<<<<<<< HEAD
             "version": "2.2",
             "source": {
                 "type": "git",
@@ -3694,26 +3702,6 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-mod/version/zipball/2fc90b9ce281b10efa68ebc90a6b339515aba35f",
                 "reference": "2fc90b9ce281b10efa68ebc90a6b339515aba35f",
-=======
-            "version": "dev-master",
-=======
-            "version": "2.2",
->>>>>>> Updated dependencies
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-mod/version.git",
-                "reference": "2fc90b9ce281b10efa68ebc90a6b339515aba35f"
-            },
-            "dist": {
-                "type": "zip",
-<<<<<<< HEAD
-                "url": "https://api.github.com/repos/php-mod/version/zipball/5a3f17a41b449e25d9f83a4503d02e977ca9ebb1",
-                "reference": "5a3f17a41b449e25d9f83a4503d02e977ca9ebb1",
->>>>>>> Compare tags with version suffixes
-=======
-                "url": "https://api.github.com/repos/php-mod/version/zipball/2fc90b9ce281b10efa68ebc90a6b339515aba35f",
-                "reference": "2fc90b9ce281b10efa68ebc90a6b339515aba35f",
->>>>>>> Updated dependencies
                 "shasum": ""
             },
             "require": {
@@ -3746,15 +3734,7 @@
                 "semantic",
                 "version"
             ],
-<<<<<<< HEAD
-<<<<<<< HEAD
             "time": "2015-06-07 19:06:40"
-=======
-            "time": "2015-06-07 16:18:01"
->>>>>>> Compare tags with version suffixes
-=======
-            "time": "2015-06-07 19:06:40"
->>>>>>> Updated dependencies
         },
         {
             "name": "vlucas/phpdotenv",

--- a/composer.lock
+++ b/composer.lock
@@ -1443,7 +1443,12 @@
         },
         {
             "name": "laravel/framework",
+<<<<<<< HEAD
             "version": "v5.2.22",
+=======
+<<<<<<< HEAD
+            "version": "v5.2.20",
+>>>>>>> Updated dependencies
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
@@ -1451,8 +1456,25 @@
             },
             "dist": {
                 "type": "zip",
+<<<<<<< HEAD
                 "url": "https://api.github.com/repos/laravel/framework/zipball/aec1b7cb9ec0bac0107361a3730cac9b6f945ef4",
                 "reference": "aec1b7cb9ec0bac0107361a3730cac9b6f945ef4",
+=======
+                "url": "https://api.github.com/repos/laravel/framework/zipball/d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
+                "reference": "d4ff9a1e3e9b2f99f8f3e957876e343d804d944f",
+=======
+            "version": "v5.2.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/framework.git",
+                "reference": "39e89553c124dce266da03ee3c0260bdd62f1848"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/39e89553c124dce266da03ee3c0260bdd62f1848",
+                "reference": "39e89553c124dce266da03ee3c0260bdd62f1848",
+>>>>>>> Updated dependencies
+>>>>>>> Updated dependencies
                 "shasum": ""
             },
             "require": {
@@ -1567,7 +1589,15 @@
                 "framework",
                 "laravel"
             ],
+<<<<<<< HEAD
             "time": "2016-02-27 22:09:19"
+=======
+<<<<<<< HEAD
+            "time": "2016-02-19 17:58:28"
+=======
+            "time": "2016-02-15 17:46:58"
+>>>>>>> Updated dependencies
+>>>>>>> Updated dependencies
         },
         {
             "name": "league/flysystem",
@@ -3580,6 +3610,7 @@
         {
             "name": "version/version",
 <<<<<<< HEAD
+<<<<<<< HEAD
             "version": "2.2",
             "source": {
                 "type": "git",
@@ -3592,16 +3623,24 @@
                 "reference": "2fc90b9ce281b10efa68ebc90a6b339515aba35f",
 =======
             "version": "dev-master",
+=======
+            "version": "2.2",
+>>>>>>> Updated dependencies
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-mod/version.git",
-                "reference": "5a3f17a41b449e25d9f83a4503d02e977ca9ebb1"
+                "reference": "2fc90b9ce281b10efa68ebc90a6b339515aba35f"
             },
             "dist": {
                 "type": "zip",
+<<<<<<< HEAD
                 "url": "https://api.github.com/repos/php-mod/version/zipball/5a3f17a41b449e25d9f83a4503d02e977ca9ebb1",
                 "reference": "5a3f17a41b449e25d9f83a4503d02e977ca9ebb1",
 >>>>>>> Compare tags with version suffixes
+=======
+                "url": "https://api.github.com/repos/php-mod/version/zipball/2fc90b9ce281b10efa68ebc90a6b339515aba35f",
+                "reference": "2fc90b9ce281b10efa68ebc90a6b339515aba35f",
+>>>>>>> Updated dependencies
                 "shasum": ""
             },
             "require": {
@@ -3635,10 +3674,14 @@
                 "version"
             ],
 <<<<<<< HEAD
+<<<<<<< HEAD
             "time": "2015-06-07 19:06:40"
 =======
             "time": "2015-06-07 16:18:01"
 >>>>>>> Compare tags with version suffixes
+=======
+            "time": "2015-06-07 19:06:40"
+>>>>>>> Updated dependencies
         },
         {
             "name": "vlucas/phpdotenv",
@@ -5872,15 +5915,9 @@
             "time": "2015-05-27 22:58:02"
         }
     ],
-    "aliases": [
-        {
-            "alias": "2.2",
-            "alias_normalized": "2.2.0.0",
-            "version": "9999999-dev",
-            "package": "version/version"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
+<<<<<<< HEAD
     "stability-flags": {
 <<<<<<< HEAD
         "andywer/js-localization": 20
@@ -5888,6 +5925,9 @@
         "version/version": 20
 >>>>>>> Compare tags with version suffixes
     },
+=======
+    "stability-flags": [],
+>>>>>>> Updated dependencies
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/config/ide-helper.php
+++ b/config/ide-helper.php
@@ -1,0 +1,119 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filename & Format
+    |--------------------------------------------------------------------------
+    |
+    | The default filename (without extension) and the format (php or json)
+    |
+    */
+
+    'filename'  => '_ide_helper',
+    'format'    => 'php',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Helper files to include
+    |--------------------------------------------------------------------------
+    |
+    | Include helper files. By default not included, but can be toggled with the
+    | -- helpers (-H) option. Extra helper files can be included.
+    |
+    */
+
+    'include_helpers' => false,
+
+    'helper_files' => [
+        base_path() . '/vendor/laravel/framework/src/Illuminate/Support/helpers.php',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Model locations to include
+    |--------------------------------------------------------------------------
+    |
+    | Define in which directories the ide-helper:models command should look
+    | for models.
+    |
+    */
+
+    'model_locations' => [
+        'app',
+    ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Extra classes
+    |--------------------------------------------------------------------------
+    |
+    | These implementations are not really extended, but called with magic functions
+    |
+    */
+
+    'extra' => [
+        'Eloquent' => ['Illuminate\Database\Eloquent\Builder', 'Illuminate\Database\Query\Builder'],
+        'Session' => ['Illuminate\Session\Store'],
+    ],
+
+    'magic' => [
+        'Log' => [
+            'debug'     => 'Monolog\Logger::addDebug',
+            'info'      => 'Monolog\Logger::addInfo',
+            'notice'    => 'Monolog\Logger::addNotice',
+            'warning'   => 'Monolog\Logger::addWarning',
+            'error'     => 'Monolog\Logger::addError',
+            'critical'  => 'Monolog\Logger::addCritical',
+            'alert'     => 'Monolog\Logger::addAlert',
+            'emergency' => 'Monolog\Logger::addEmergency',
+        ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Interface implementations
+    |--------------------------------------------------------------------------
+    |
+    | These interfaces will be replaced with the implementing class. Some interfaces
+    | are detected by the helpers, others can be listed below.
+    |
+    */
+
+    'interfaces' => [
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Support for custom DB types
+    |--------------------------------------------------------------------------
+    |
+    | This setting allow you to map any custom database type (that you may have
+    | created using CREATE TYPE statement or imported using database plugin
+    | / extension to a Doctrine type.
+    |
+    | Each key in this array is a name of the Doctrine2 DBAL Platform. Currently valid names are:
+    | 'postgresql', 'db2', 'drizzle', 'mysql', 'oracle', 'sqlanywhere', 'sqlite', 'mssql'
+    |
+    | This name is returned by getName() method of the specific Doctrine/DBAL/Platforms/AbstractPlatform descendant
+    |
+    | The value of the array is an array of type mappings. Key is the name of the custom type,
+    | (for example, "jsonb" from Postgres 9.4) and the value is the name of the corresponding Doctrine2 type (in
+    | our case it is 'json_array'. Doctrine types are listed here:
+    | http://doctrine-dbal.readthedocs.org/en/latest/reference/types.html
+    |
+    | So to support jsonb in your models when working with Postgres, just add the following entry to the array below:
+    |
+    | "postgresql" => array(
+    |       "jsonb" => "json_array",
+    |  ),
+    |
+    */
+    'custom_db_types' => [
+
+    ],
+
+];

--- a/database/migrations/2015_12_10_073606_add_last_mirrored_date.php
+++ b/database/migrations/2015_12_10_073606_add_last_mirrored_date.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLastMirroredDate extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dateTime('last_mirrored')->nullable()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropColumn('last_mirrored');
+        });
+    }
+}

--- a/database/migrations/2015_12_10_073606_add_last_mirrored_date.php
+++ b/database/migrations/2015_12_10_073606_add_last_mirrored_date.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 
 class AddLastMirroredDate extends Migration
 {

--- a/database/seeds/CommandTableSeeder.php
+++ b/database/seeds/CommandTableSeeder.php
@@ -8,17 +8,16 @@ class CommandTableSeeder extends Seeder
     private function getScript()
     {
         return <<< EOD
-
-        echo "Release {{ release }}"
-        echo "Release Path {{ release_path }}"
-        echo "Project Path {{ project_path }}"
-        echo "Branch {{ branch }}"
-        echo "SHA {{ sha }}"
-        echo "Short SHA {{ short_sha }}"
-        echo "Deployer email {{ deployer_email }}"
-        echo "Deployer name {{ deployer_name }}"
-        echo "Committer email {{ committer_email }}"
-        echo "Committer name {{ committer_name }}"
+echo "Release {{ release }}"
+echo "Release Path {{ release_path }}"
+echo "Project Path {{ project_path }}"
+echo "Branch {{ branch }}"
+echo "SHA {{ sha }}"
+echo "Short SHA {{ short_sha }}"
+echo "Deployer email {{ deployer_email }}"
+echo "Deployer name {{ deployer_name }}"
+echo "Committer email {{ committer_email }}"
+echo "Committer name {{ committer_name }}"
 EOD;
     }
 
@@ -32,6 +31,7 @@ EOD;
             'project_id' => 1,
             'user'       => 'deploy',
             'step'       => Command::BEFORE_CLONE,
+            'optional'   => true,
         ])->servers()->attach([1, 2]);
 
         Command::create([
@@ -88,6 +88,7 @@ EOD;
             'project_id' => 1,
             'user'       => 'deploy',
             'step'       => Command::AFTER_PURGE,
+            'optional'   => true,
         ])->servers()->attach([1, 2]);
     }
 }

--- a/examples/dev/redis-commander.conf
+++ b/examples/dev/redis-commander.conf
@@ -4,8 +4,8 @@ directory=/root
 numprocs=1
 autostart=true
 autorestart=true
-environment=USER=root,HOME=/root,NODE_ENV=production
+environment=USER="root",HOME="/root",NODE_ENV="production"
 stderr_logfile=/var/log/supervisor/redis-commander-stderr.log
-stdout_logfile=/var/log/supervisor/eredis-commander-stdout.log
+stdout_logfile=/var/log/supervisor/redis-commander-stdout.log
 stderr_logfile_maxbytes=1MB
 stdout_logfile_maxbytes=1MB

--- a/examples/supervisor.conf
+++ b/examples/supervisor.conf
@@ -4,8 +4,8 @@ directory=/var/www/deployer
 process_name=queue_%(process_num)s
 numprocs=3
 numprocs_start=0
-stdout_logfile=/var/www/deployer/storage/logs/supervisord-%(process_num)s-stdout.log
-stderr_logfile=/var/www/deployer/storage/logs/supervisord-%(process_num)s-stderr.log
+stdout_logfile=/var/log/supervisor/deployer-%(process_num)s-stdout.log
+stderr_logfile=/var/log/supervisor/deployer-%(process_num)s-stderr.log
 stderr_logfile_maxbytes=1MB
 stdout_logfile_maxbytes=1MB
 redirect_stderr=true
@@ -18,9 +18,9 @@ directory=/var/www/deployer
 numprocs=1
 autostart=true
 autorestart=true
-environment=NODE_ENV=production
-stderr_logfile=/var/www/deployer/storage/logs/node-stderr.log
-stdout_logfile=/var/www/deployer/storage/logs/node-stdout.log
+environment=HOME="/var/www/deployer",NODE_ENV="production"
+stderr_logfile=/var/log/supervisor/deployer-socket-stderr.log
+stdout_logfile=/var/log/supervisor/deployer-socket-stdout.log
 stderr_logfile_maxbytes=1MB
 stdout_logfile_maxbytes=1MB
 
@@ -28,8 +28,8 @@ stdout_logfile_maxbytes=1MB
 command=php artisan queue:work --queue=deployer-default --sleep=3 --tries=1 --daemon
 directory=/var/www/deployer
 numprocs=1
-stderr_logfile=/var/www/deployer/storage/logs/broadcast-stderr.log
-stdout_logfile=/var/www/deployer/storage/logs/broadcast-stdout.log
+stderr_logfile=/var/log/supervisor/deployer-broadcast-stderr.log
+stdout_logfile=/var/log/supervisor/deployer-broadcast-stdout.log
 stderr_logfile_maxbytes=1MB
 stdout_logfile_maxbytes=1MB
 redirect_stderr=true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,19 +29,21 @@ var paths = {
     'respond'         : bower_path + '/respond',
     'cropper'         : bower_path + '/cropper',
     'toastr'          : bower_path + '/toastr',
+    'select2'         : bower_path + '/admin-lte/plugins/select2',
     'localization'    : 'vendor/andywer/js-localization'
 };
 
 elixir(function(mix) {
     mix.Bower()
     .styles([
-        paths.admin_lte + '/bootstrap/css/bootstrap.css',
+        paths.admin_lte   + '/bootstrap/css/bootstrap.css',
+        paths.select2     + '/select2.css',
         paths.fontawesome + '/css/font-awesome.css',
         paths.ionicons    + '/css/ionicons.css',
-        paths.admin_lte + '/dist/css/AdminLTE.css',
-        paths.admin_lte + '/dist/css/skins/_all-skins.css',
-        paths.toastr    + '/toastr.css',
-        paths.cropper   + '/dist/cropper.css',
+        paths.admin_lte   + '/dist/css/AdminLTE.css',
+        paths.admin_lte   + '/dist/css/skins/_all-skins.css',
+        paths.toastr      + '/toastr.css',
+        paths.cropper     + '/dist/cropper.css',
     ], 'public/css/vendor.css', './')
     .styles([
         'resources/assets/css/app.css'
@@ -57,6 +59,7 @@ elixir(function(mix) {
         paths.underscore      + '/underscore.js',
         paths.moment          + '/moment.js',
         paths.admin_lte       + '/bootstrap/js/bootstrap.js',
+        paths.select2         + '/select2.js',
         paths.admin_lte       + '/dist/js/app.js',
         paths.backbone        + '/backbone.js',
         paths.socketio_client + '/socket.io.js',

--- a/resources/assets/css/app.css
+++ b/resources/assets/css/app.css
@@ -95,8 +95,9 @@ span.label i.fa {
     margin-right: 2px;
 }
 
-select.deployment-source {
+div.deployment-source-container {
     display: none;
+    margin-top: 5px;
 }
 
 #command_script,
@@ -112,6 +113,10 @@ select.deployment-source {
 
 #repository_error {
     display: none;
+}
+
+div#reason div.radio label {
+    min-width: 50%;
 }
 
 #deploying_menu li a p,

--- a/resources/assets/js/deployment.js
+++ b/resources/assets/js/deployment.js
@@ -11,13 +11,16 @@ var app = app || {};
         var button = $(event.relatedTarget);
 
         var deployment = button.data('deployment-id');
-        var commands = [];
 
-        var tmp = button.data('optional-commands');
+        var tmp = button.data('optional-commands') + '';
+        var commands = tmp.split(',');
+
         if (tmp.length > 0) {
-            commands = $.map(tmp.split(','), function(value) {
+            commands = $.map(commands, function(value) {
                 return parseInt(value, 10);
             });
+        } else {
+            commands = [];
         }
 
         var modal = $(this);

--- a/resources/assets/js/deployment.js
+++ b/resources/assets/js/deployment.js
@@ -7,6 +7,33 @@ var app = app || {};
     var FAILED    = 3;
     var CANCELLED = 4;
 
+    $('#redeploy').on('show.bs.modal', function(event) {
+        var button = $(event.relatedTarget);
+
+        var deployment = button.data('deployment-id');
+        var commands = [];
+
+        var tmp = button.data('optional-commands');
+        if (tmp.length > 0) {
+            commands = $.map(tmp.split(','), function(value) {
+                return parseInt(value, 10);
+            });
+        }
+
+        var modal = $(this);
+
+        $('form', modal).prop('action', '/deployment/' + deployment + '/rollback');
+
+        $('input:checkbox', modal).each(function (index, element) {
+            var input = $(element);
+
+            input.prop('checked', false);
+            if ($.inArray(parseInt(input.val(), 10), commands) != -1) {
+                input.prop('checked', true);
+            }
+        });
+    });
+
     $('#log').on('show.bs.modal', function (event) {
         var button = $(event.relatedTarget);
         var log_id = button.attr('id').replace('log_', '');

--- a/resources/assets/js/projects.js
+++ b/resources/assets/js/projects.js
@@ -1,14 +1,19 @@
 var app = app || {};
 
 (function ($) {
+    $('select.deployment-source').select2({
+        width: '100%',
+        minimumResultsForSearch: 6
+    });
+
     $('.deployment-source:radio').on('change', function (event) {
         var target = $(event.currentTarget);
 
-        $('select.deployment-source').hide();
+        $('div.deployment-source-container').hide();
         if (target.val() === 'branch') {
-            $('#deployment_branch').show();
+            $('#deployment_branch').parent('div').show();
         } else if (target.val() === 'tag') {
-            $('#deployment_tag').show();
+            $('#deployment_tag').parent('div').show();
         }
     });
 

--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -13,6 +13,7 @@ return [
     'users'             => 'Users',
     'created'           => 'Created',
     'edit'              => 'Edit',
+    'confirm'           => 'Confirm',
     'not_applicable'    => 'N/A',
     'date'              => 'Date',
     'status'            => 'Status',

--- a/resources/lang/en/commands.php
+++ b/resources/lang/en/commands.php
@@ -32,7 +32,7 @@ return [
     'project_path'         => 'The project path',
     'after'                => 'After',
     'configure'            => 'Configure',
-    'clone'                => 'Clone New Release',
+    'clone'                => 'Create New Release',
     'install'              => 'Install Composer Dependencies',
     'activate'             => 'Activate New Release',
     'purge'                => 'Purge Old Releases',

--- a/resources/lang/en/deployments.php
+++ b/resources/lang/en/deployments.php
@@ -11,7 +11,13 @@ return [
     'commit'                => 'Commit',
     'manually'              => 'Manually',
     'webhook'               => 'Webhook',
-    'reactivate'            => 'Re-activate',
+    'rollback'              => 'Rollback',
+    'rollback_title'        => 'Rollback to a previous deployment',
+    'expert'                => 'You should not rollback to previous deployments unless you a confident you can perform any additional '.
+                               'cleanup which may be required.',
+    'rollback_warning'      => 'When rolling back to a previous deployment you may need to manually connect to your servers and run '.
+                               'any database rollbacks or similar, this can not be done automatically.',
+    'caution'               => 'Caution!',
     'cancel'                => 'Cancel',
     'loading'               => 'Loading',
     'unknown'               => 'Unknown',

--- a/resources/lang/en/projects.php
+++ b/resources/lang/en/projects.php
@@ -32,6 +32,7 @@ return [
     'ssh_key'           => 'SSH key',
     'deploy_project'    => 'Deploy the project',
     'deploy'            => 'Deploy',
+    'redeploy'          => 'Redeploy',
     'server_keys'       => 'This key must be added to the server\'s <code>~/.ssh/authorized_keys</code> ' .
                            'for each user you wish to run commands as.',
     'gitlab_keys'       => 'The key will also need to be added to the <strong>Deploy Keys</strong> ' .

--- a/resources/views/dialogs/reason.blade.php
+++ b/resources/views/dialogs/reason.blade.php
@@ -32,11 +32,13 @@
                                     <label for="deployment_source_branch">
                                         <input type="radio" class="deployment-source" name="source" id="deployment_source_branch" value="branch" /> {{ Lang::get('deployments.different_branch') }}
 
-                                        <select class="form-control deployment-source" name="source_branch" id="deployment_branch">
-                                            @foreach ($branches as $branch)
-                                                <option value="{{ $branch }}">{{ $branch }}</option>
-                                            @endforeach
-                                        </select>
+                                        <div class="deployment-source-container">
+                                            <select class="form-control deployment-source" name="source_branch" id="deployment_branch">
+                                                @foreach ($branches as $branch)
+                                                    <option value="{{ $branch }}">{{ $branch }}</option>
+                                                @endforeach
+                                            </select>
+                                        </div>
                                     </label>
                                 </div>
                             </li>
@@ -48,12 +50,13 @@
                                     <label for="deployment_source_tag">
                                         <input type="radio" class="deployment-source" name="source" id="deployment_source_tag" value="tag" /> {{ Lang::get('deployments.tag') }}
 
-                                        <select class="form-control deployment-source" name="source_tag" id="deployment_tag">
-                                            @foreach ($tags as $tag)
-                                                <option value="{{ $tag }}">{{ $tag }}</option>
-                                            @endforeach
-                                        </select>
-
+                                        <div class="deployment-source-container">
+                                            <select class="form-control deployment-source" name="source_tag" id="deployment_tag">
+                                                @foreach ($tags as $tag)
+                                                    <option value="{{ $tag }}">{{ $tag }}</option>
+                                                @endforeach
+                                            </select>
+                                        </div>
                                     </label>
                                 </div>
                             </li>

--- a/resources/views/dialogs/redeploy.blade.php
+++ b/resources/views/dialogs/redeploy.blade.php
@@ -1,0 +1,26 @@
+<div class="modal modal-default fade" id="redeploy">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
+                <h4 class="modal-title"><i class="fa fa-cloud-upload"></i> {{ Lang::get('deployments.rollback_title') }}</h4>
+            </div>
+            <form role="form" method="post" action="{{ route('rollback', ['deployment' => '?']) }}">
+                <input type="hidden" name="_token" value="{{ csrf_token() }}" />
+                <div class="modal-body">
+
+                    <div class="alert alert-danger">
+                        <h4>{{ Lang::get('deployments.caution') }}</h4>
+                        <p>{{ Lang::get('deployments.expert') }}</p>
+                        <br />
+                        <p>{{ Lang::get('deployments.rollback_warning') }}</p>
+                    </div>
+                </div>
+
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary pull-right"><i class="fa fa-save"></i> {{ Lang::get('app.confirm') }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/resources/views/dialogs/redeploy.blade.php
+++ b/resources/views/dialogs/redeploy.blade.php
@@ -5,7 +5,7 @@
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button>
                 <h4 class="modal-title"><i class="fa fa-cloud-upload"></i> {{ Lang::get('deployments.rollback_title') }}</h4>
             </div>
-            <form role="form" method="post" action="{{ route('rollback', ['deployment' => '?']) }}">
+            <form role="form" method="post">
                 <input type="hidden" name="_token" value="{{ csrf_token() }}" />
                 <div class="modal-body">
 

--- a/resources/views/dialogs/redeploy.blade.php
+++ b/resources/views/dialogs/redeploy.blade.php
@@ -15,10 +15,34 @@
                         <br />
                         <p>{{ Lang::get('deployments.rollback_warning') }}</p>
                     </div>
+                    <hr />
+                    <div class="form-group">
+                        <label for="deployment_reason">{{ Lang::get('deployments.describe_reason') }}</label>
+                        <textarea rows="10" id="deployment_reason" class="form-control" name="reason" placeholder="For example, Allows users to reset their password"></textarea>
+                    </div>
+                    @if (count($optional))
+                    <div class="form-group">
+                        <label for="command_servers">{{ Lang::get('deployments.optional') }}</label>
+                        <ul class="list-unstyled">
+                            @foreach ($optional as $command)
+                            <li>
+                                <div class="checkbox">
+                                    <label for="deployment_command_{{ $command->id }}">
+                                        <input type="checkbox" class="deployment-command" name="optional[]" id="deployment_command_{{ $command->id }}" value="{{ $command->id }}" @if ($command->default_on === true) checked @endif/> {{ $command->name }}
+                                    </label>
+                                </div>
+                            </li>
+                            @endforeach
+                        </ul>
+                        <div class="callout callout-info">
+                            <p>NOTE: The commands which were included in the previous deployment have already been selected</p>
+                        </div>
+                    </div>
+                    @endif
                 </div>
 
                 <div class="modal-footer">
-                    <button type="submit" class="btn btn-primary pull-right"><i class="fa fa-save"></i> {{ Lang::get('app.confirm') }}</button>
+                    <button type="submit" class="btn btn-primary pull-right"><i class="fa fa-save"></i> {{ Lang::get('projects.redeploy') }}</button>
                 </div>
             </form>
         </div>

--- a/resources/views/dialogs/redeploy.blade.php
+++ b/resources/views/dialogs/redeploy.blade.php
@@ -34,9 +34,6 @@
                             </li>
                             @endforeach
                         </ul>
-                        <div class="callout callout-info">
-                            <p>NOTE: The commands which were included in the previous deployment have already been selected</p>
-                        </div>
                     </div>
                     @endif
                 </div>

--- a/resources/views/projects/_partials/deployments.blade.php
+++ b/resources/views/projects/_partials/deployments.blade.php
@@ -53,12 +53,13 @@
                     </td>
                     <td>
                         <div class="btn-group pull-right">
-                            @if($deployment->isSuccessful() && !$deployment->isCurrent())
-                            <button type="button" class="btn btn-default btn-redeploy" title="{{ Lang::get('deployments.reactivate') }}"><i class="fa fa-cloud-upload"></i></button>
+                            @if ($deployment->isSuccessful() && !$deployment->isCurrent())
+                                <button type="button" data-toggle="modal" data-backdrop="static" data-target="#redeploy" data-deployment-id="{{ $deployment->id }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></button>
                             @endif
-                            @if($deployment->isPending() || $deployment->isRunning())
-                            <!-- FIXME: Try and change this to a form as abort should be a POST request -->
-                            <a href="{{ route('abort', ['id' => $deployment->id])  }}" class="btn btn-default btn-cancel" title="{{ Lang::get('deployments.cancel') }}"><i class="fa fa-ban"></i></a>
+
+                            @if ($deployment->isPending() || $deployment->isRunning())
+                                <!-- FIXME: Try and change this to a form as abort should be a POST request -->
+                                <a href="{{ route('abort', ['id' => $deployment->id])  }}" class="btn btn-default" title="{{ Lang::get('deployments.cancel') }}"><i class="fa fa-ban"></i></a>
                             @endif
                             <a href="{{ route('deployment', ['id' => $deployment->id]) }}" type="button" class="btn btn-default" title="{{ Lang::get('app.details') }}"><i class="fa fa-info-circle"></i></a>
                         </div>

--- a/resources/views/projects/_partials/deployments.blade.php
+++ b/resources/views/projects/_partials/deployments.blade.php
@@ -54,8 +54,8 @@
                     <td>
                         <div class="btn-group pull-right">
                             @if ($deployment->isSuccessful() && !$deployment->isCurrent())
-                                <!--button type="button" data-toggle="modal" data-backdrop="static" data-target="#redeploy" data-deployment-id="{{ $deployment->id }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></button-->
-                                <a href="{{ route('rollback', ['id' => $deployment->id]) }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></a>
+                                <button type="button" data-toggle="modal" data-backdrop="static" data-target="#redeploy" data-optional-commands="{{ $deployment->optional_commands_used }}" data-deployment-id="{{ $deployment->id }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></button>
+                                <!--a href="{{ route('rollback', ['id' => $deployment->id]) }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></a-->
                             @endif
 
                             @if ($deployment->isPending() || $deployment->isRunning())

--- a/resources/views/projects/_partials/deployments.blade.php
+++ b/resources/views/projects/_partials/deployments.blade.php
@@ -54,12 +54,13 @@
                     <td>
                         <div class="btn-group pull-right">
                             @if ($deployment->isSuccessful() && !$deployment->isCurrent())
-                                <button type="button" data-toggle="modal" data-backdrop="static" data-target="#redeploy" data-deployment-id="{{ $deployment->id }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></button>
+                                <!--button type="button" data-toggle="modal" data-backdrop="static" data-target="#redeploy" data-deployment-id="{{ $deployment->id }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></button-->
+                                <a href="{{ route('rollback', ['id' => $deployment->id]) }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></a>
                             @endif
 
                             @if ($deployment->isPending() || $deployment->isRunning())
                                 <!-- FIXME: Try and change this to a form as abort should be a POST request -->
-                                <a href="{{ route('abort', ['id' => $deployment->id])  }}" class="btn btn-default" title="{{ Lang::get('deployments.cancel') }}"><i class="fa fa-ban"></i></a>
+                                <a href="{{ route('abort', ['id' => $deployment->id]) }}" class="btn btn-default" title="{{ Lang::get('deployments.cancel') }}"><i class="fa fa-ban"></i></a>
                             @endif
                             <a href="{{ route('deployment', ['id' => $deployment->id]) }}" type="button" class="btn btn-default" title="{{ Lang::get('app.details') }}"><i class="fa fa-info-circle"></i></a>
                         </div>

--- a/resources/views/projects/_partials/deployments.blade.php
+++ b/resources/views/projects/_partials/deployments.blade.php
@@ -55,7 +55,6 @@
                         <div class="btn-group pull-right">
                             @if ($deployment->isSuccessful() && !$deployment->isCurrent())
                                 <button type="button" data-toggle="modal" data-backdrop="static" data-target="#redeploy" data-optional-commands="{{ $deployment->optional_commands_used }}" data-deployment-id="{{ $deployment->id }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></button>
-                                <!--a href="{{ route('rollback', ['id' => $deployment->id]) }}" class="btn btn-default" title="{{ Lang::get('deployments.rollback') }}"><i class="fa fa-cloud-upload"></i></a-->
                             @endif
 
                             @if ($deployment->isPending() || $deployment->isRunning())

--- a/resources/views/projects/details.blade.php
+++ b/resources/views/projects/details.blade.php
@@ -101,6 +101,7 @@
     @include('dialogs.check_urls')
     @include('dialogs.key')
     @include('dialogs.reason')
+    @include('dialogs.redeploy')
 @stop
 
 @section('right-buttons')

--- a/socket.js
+++ b/socket.js
@@ -11,7 +11,6 @@ var redis = new Redis({
 });
 
 if (/^https/i.test(process.env.SOCKET_URL)) {
-
     var ssl_conf = {
         key:  (process.env.SOCKET_SSL_KEY_FILE  ? fs.readFileSync(process.env.SOCKET_SSL_KEY_FILE)  : null),
         cert: (process.env.SOCKET_SSL_CERT_FILE ? fs.readFileSync(process.env.SOCKET_SSL_CERT_FILE) : null),
@@ -45,7 +44,6 @@ io.use(function(socket, next) {
     }
 
     try {
-
         decoded = jwt.verify(socket.handshake.query.jwt, process.env.JWT_SECRET);
 
         if (debug) {

--- a/storage/app/.gitignore
+++ b/storage/app/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!mirrors

--- a/storage/app/mirrors/.gitignore
+++ b/storage/app/mirrors/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Last night I changedDeployer so that it mirrors the git repository in the project directory as mirror.git, then when you deploy it updates that and then does a shallow clone using that as the source.

That way you don't have to continually download the same files everytime you deploy, only files which have updated.

This obviously means the initial deploy is slower, and it uses more space on the server but later deploys are faster and transfer less data

However, I still have to check it out locally to the Deployer server in order to get the commit info.

So I was thinking, instead have mirrors of the repos on the Deployer server; and instead have Deployer tar up the last commit, transfer it to the server and untar it rather than running git on the server

Having a mirror means the rollback is actually possible, and having it on the Deployer server means I can show a list of branches and tags rather than just text fields

So what do you think?

It obviously means the Deployer server will take up more space though

(Obviously getting a specific revision, list of tags/branches and the commit info without cloning the repository is doable with the APIs for gitlab, github and bitbucket but I want to support all types of git repositories if possible)


- [x] Mirror the repositories to `storage/app`
- [x] Update installer to check `tar` command exists
- [x] Update deploy process to clone from the mirror locally, then tar the revision to be deployed then scp to the remote server & replace the "Clone new release" step
- [x] Rename the "Clone new release" step?
- [x] Change `scp` command to `rsync` so we can get progress
- [x] Update deploy process to untar the file and delete the archive
- [x] Use select2 on deployment dialog for dropdowns
- [ ] ~~Update project deletion to remove mirrors~~
- [ ] ~~Update project editing to remove mirror if repo is changed, could try renaming and changing the remote?~~
- [x] Add a cronjob to remove orphan mirrors
- [x] Add a cronjob to update mirrors
- [x] Use the mirrors to get a list of tags and branches
- [x] Update the deploy dialog to show branches and tags
- [x] Implement rollback using the mirrors
- [x] Implement deploying a specific revision, needed for rollback
- [ ] ~~Refactor DeployProject, getScript should *NOT* be uploading files~~ Not going to do as part of this PR
- [ ] Ensure it is clear what the error is if there is a problem when cloning the repository
- [x] Ensure the transfer times are included in the runtime