### PR TITLE
Fixes an error thrown by timeline component if there's no timeline data

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -38,7 +38,7 @@ class DashboardController extends Controller
     {
         return view('app', [
             'projects' => $this->buildProjectData(),
-            'latest' => json_encode($this->buildTimelineData()),
+            'latest' => json_encode($this->buildTimelineData(), JSON_FORCE_OBJECT),
         ]);
     }
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/10898472/16709443/0e848e68-45df-11e6-88d6-466745df7e55.png)

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.

---

### Description of change

Fixes my error where if there was no timeline data, an empty array was passed to timeline (which expected an object)