### PR TITLE
Possible fix for toJS issue in NavButtons

### DIFF
--- a/resources/assets/js/app/containers/NavButtons.jsx
+++ b/resources/assets/js/app/containers/NavButtons.jsx
@@ -11,7 +11,7 @@ NavButtons.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  buttons: state.getIn([constants.NAME, 'buttons']), // .toJS(),
+  buttons: state.getIn([constants.NAME, 'buttons']).toJS(),
 });
 
 export default connect(mapStateToProps)(NavButtons);

--- a/resources/assets/js/navigation/reducer.js
+++ b/resources/assets/js/navigation/reducer.js
@@ -13,7 +13,7 @@ const initialState = Immutable.fromJS({
 export default function (state = initialState, action) {
   switch (action.type) {
     case actions.SET_BUTTONS:
-      return state.set('buttons', action.buttons);
+      return state.set('buttons', Immutable.fromJS(action.buttons));
     default:
       return state;
   }


### PR DESCRIPTION
![Image](http://25.media.tumblr.com/d87be13c5a4d4847c873ae39b540a86c/tumblr_mz7wo1IdGi1svw14do1_400.gif)

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.

---

### Description of change

Here's what I think is happening: in the initial state, `buttons` is set to an immutable array, but later, when `buttons` is updated by the `SET_BUTTONS` action, the whole array is being replaced with a new one. Since Immutable isn't recursive, that new array doesn't itself become immutable, so calling `toJS` on it throws an error. I verified this by logging the state in `NavButtons` - it started off logging an empty `List`, but later logged a real JS array - meaning the immutable `List` type was getting lost after the state update.

The fix provided works by calling `Immutable.fromJS` in the reducer when `SET_BUTTONS` is fired. That seems like the appropriate place to me, but see what you think.

In other news, I think I've figured out how to do the branching so it doesn't include all the merges.
