### PR TITLE
[IMPROVEMENT] Priority WS for optimal transport browser

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -6,12 +6,10 @@ server {
     listen 80;
     server_name deployer.app;
     root "/var/www/deployer/public";
-
-    index index.php;
-
     charset utf-8;
 
     location / {
+        index index.php;
         try_files $uri $uri/ /index.php?$query_string;
     }
 
@@ -42,7 +40,7 @@ server {
         proxy_pass http://websocket;
     }
 
-    location ~ /\.ht {
+    location ~* /\.(?!well-known\/) {
         deny all;
     }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -39,7 +39,8 @@ toastr.options.extendedTimeOut = 7000;
     app.project_id = app.project_id || null;
 
     app.listener = io.connect($('meta[name="socket_url"]').attr('content'), {
-        query: 'jwt=' + $('meta[name="jwt"]').attr('content')
+        query: 'jwt=' + $('meta[name="jwt"]').attr('content'),
+        transports: ['websocket', 'polling']
     });
 
     app.connection_error = false;


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I have considered, and confirmed that this submission will be valuable to others.
- [ ] Do the PHPCI tests pass?
- [ ] Does the StyleCI test pass?

---

### Description of change

Without these changes, we will always be `pulling` even if there is implementation of `websocket`.

+ Access to `/.well-known/` is allowed RFC5785 (Let's Encrypt).

```diff
     app.listener = io.connect($('meta[name="socket_url"]').attr('content'), {
        query: 'jwt=' + $('meta[name="jwt"]').attr('content'),
+        transports: ['websocket', 'polling']
     });
```