### PR TITLE
[IMPROVEMENT] Ignore suggestions when installing Composer deps

### DIFF
--- a/resources/scripts/deploy/steps/InstallComposerDependencies.sh
+++ b/resources/scripts/deploy/steps/InstallComposerDependencies.sh
@@ -25,10 +25,10 @@ if [ -f {{ release_path }}/composer.json ]; then
 
     if [ -n "{{ include_dev }}" ]; then
         ${composer} install --no-interaction --optimize-autoloader \
-                          --prefer-dist --no-ansi --working-dir "{{ release_path }}"
+                          --prefer-dist --no-suggest --no-ansi --working-dir "{{ release_path }}"
     else
         ${composer} install --no-interaction --optimize-autoloader \
-                          --no-dev --prefer-dist --no-ansi --working-dir "{{ release_path }}"
+                          --no-dev --prefer-dist --no-suggest --no-ansi --working-dir "{{ release_path }}"
     fi
 fi
 


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] Do the PHPCI tests pass?
- [x] Does the StyleCI test pass?

---

### Description of change

Composer v1.2.0 introduces a `--no-suggest` flag which stops suggestions. We now use this to slightly speed up dependency installations.

