### PR TITLE
Installer gets into an infinite loop if there are PDO drivers loaded before MySQL

### DIFF
--- a/app/Console/Commands/InstallApp.php
+++ b/app/Console/Commands/InstallApp.php
@@ -692,8 +692,8 @@ class InstallApp extends Command
     {
         $available = collect(PDO::getAvailableDrivers());
 
-        return $available->intersect(['mysql', 'sqlite', 'pgsql', 'sqlsrv'])
-                         ->all();
+        return array_values($available->intersect(['mysql', 'sqlite', 'pgsql', 'sqlsrv'])
+                         ->all());
     }
 
     /**


### PR DESCRIPTION
intersect will preserve the original collection's keys.
[ 1 =>'mysql', 2 => 'pgsql'] will fail with default index 0.