### PR TITLE
FIX fixing ssh connection issues

### DIFF
--- a/app/Jobs/DeployProject.php
+++ b/app/Jobs/DeployProject.php
@@ -85,6 +85,7 @@ class DeployProject extends Job implements ShouldQueue
 
         $this->private_key = tempnam(storage_path('app/'), 'sshkey');
         file_put_contents($this->private_key, $this->deployment->project->private_key);
+        chmod($this->private_key, 0600);
 
         $this->release_archive = $this->deployment->project_id . '_' . $this->deployment->release_id . '.tar.gz';
 

--- a/app/Jobs/TestServerConnection.php
+++ b/app/Jobs/TestServerConnection.php
@@ -40,6 +40,7 @@ class TestServerConnection extends Job implements ShouldQueue
 
         $key = tempnam(storage_path('app/'), 'sshkey');
         file_put_contents($key, $this->server->project->private_key);
+        chmod($key, 0600);
 
         try {
             $process = new Process('TestServerConnection', [

--- a/app/Jobs/UpdateGitMirror.php
+++ b/app/Jobs/UpdateGitMirror.php
@@ -40,6 +40,7 @@ class UpdateGitMirror extends Job
     {
         $private_key = tempnam(storage_path('app/'), 'sshkey');
         file_put_contents($private_key, $this->project->private_key);
+        chmod($private_key, 0600);
 
         $wrapper = with(new ScriptParser)->parseFile('tools.SSHWrapperScript', [
             'private_key' => $private_key,

--- a/app/Project.php
+++ b/app/Project.php
@@ -374,6 +374,7 @@ class Project extends ProjectRelation implements PresentableInterface
     {
         $key = tempnam(storage_path('app/'), 'sshkey');
         file_put_contents($key, $this->private_key);
+        chmod($key, 0600);
 
         $process = new Process('tools.RegeneratePublicSSHKey', [
             'key_file' => $key,


### PR DESCRIPTION
Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [contributing guidelines](https://github.com/REBElinBLUE/deployer/.github/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [ ] Do the TravisCI tests pass?
- [ ] Does the StyleCI test pass?

_NOTE: The last 2 are not required to open a PR and can be done afterwards /
while the PR is open._

---

### Description of change

*Please provide a description of the change here.*

trying to reproduce the error that doesn't let me to set my server on the project panel, I looked into the log stored in storage/app/XXXX.log and I got this message

[2016-11-08 12:26:51] production.DEBUG: ssh -o CheckHostIP=no \
    -o IdentitiesOnly=yes \
    -o StrictHostKeyChecking=no \
    -o PasswordAuthentication=no \
    -o IdentityFile=/var/projects/deployer/storage/app/sshkeyOZD8Nj \
    -p 22 XXXXXX@XXXXXX 'bash -s' << 'EOF'  etc ...

NOTE:
the file sshkey???? is removed by deployer inmediately but I just trick it filling in with the private_key field on the DB for the current project

Executing the same command by hand I got:

@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 for '/var/projects/deployer/storage/app/sshkeyOZD8Nj' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
bad permissions: ignore key: /var/projects/deployer/storage/app/sshkeyOZD8Nj

whith my change we ensure that the privatekey gots the proper permissions

right now with this change I passed the server check and I am able to deploy