### PR TITLE
[IMPROVEMENT] Add Laravel version shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](/LICENSE.md)
 [![Latest Version](https://img.shields.io/github/release/REBELinBLUE/deployer.svg?style=flat-square)](https://github.com/REBELinBLUE/deployer/releases)
 [![Gitter](https://img.shields.io/badge/chat-on%20gitter-brightgreen.svg?style=flat-square)](https://gitter.im/REBELinBLUE/deployer)
+[![Laravel Version](https://shield.with.social/cc/github/REBELinBLUE/deployer/master.svg?style=flat-square)](https://packagist.org/packages/laravel/framework)
 
 
 


### PR DESCRIPTION
This is a little Laravel versioner shield I made.

It will show the current version of laravel/framework value in composer.lock for a GH repo.