### PR TITLE
[FIX] Slack webhook format check

### DIFF
--- a/app/Http/Controllers/WebhookController.php
+++ b/app/Http/Controllers/WebhookController.php
@@ -10,6 +10,7 @@ use REBELinBLUE\Deployer\Http\Webhooks\Bitbucket;
 use REBELinBLUE\Deployer\Http\Webhooks\Custom;
 use REBELinBLUE\Deployer\Http\Webhooks\Github;
 use REBELinBLUE\Deployer\Http\Webhooks\Gitlab;
+use REBELinBLUE\Deployer\Http\Webhooks\Gogs;
 use REBELinBLUE\Deployer\Project;
 
 /**
@@ -27,6 +28,7 @@ class WebhookController extends Controller
         Bitbucket::class,
         Github::class,
         Gitlab::class,
+        Gogs::class
     ];
 
     /**

--- a/app/Http/Requests/StoreNotificationRequest.php
+++ b/app/Http/Requests/StoreNotificationRequest.php
@@ -17,8 +17,7 @@ class StoreNotificationRequest extends Request
         return [
             'name'         => 'required|max:255',
             'channel'      => 'required|max:255|channel',
-            'webhook'      => 'required|regex:/^https:\/\/hooks.slack.com' .
-                              '\/services\/[a-z0-9]+\/[a-z0-9]+\/[a-z0-9]+$/i',
+            'webhook'      => 'required|url',
             'failure_only' => 'boolean',
             'project_id'   => 'required|integer|exists:projects,id',
         ];

--- a/app/Http/Webhooks/Gogs.php
+++ b/app/Http/Webhooks/Gogs.php
@@ -3,12 +3,12 @@
 namespace REBELinBLUE\Deployer\Http\Webhooks;
 
 /**
- * Class to handle integration with Github webhooks.
+ * Class to handle integration with Gogs/Gitea webhooks.
  */
 class Gogs extends Webhook
 {
     /**
-     * Determines whether the request was from Github.
+     * Determines whether the request was from Gogs/Gitea.
      *
      * @return bool
      */

--- a/app/Http/Webhooks/Gogs.php
+++ b/app/Http/Webhooks/Gogs.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace REBELinBLUE\Deployer\Http\Webhooks;
+
+/**
+ * Class to handle integration with Github webhooks.
+ */
+class Gogs extends Webhook
+{
+    /**
+     * Determines whether the request was from Github.
+     *
+     * @return bool
+     */
+    public function isRequestOrigin()
+    {
+        return ($this->request->headers->has('X-Gogs-Event'));
+    }
+
+    /**
+     * Parses the request for a push webhook body.
+     *
+     * @return mixed Either an array of parameters for the deployment config, or false if it is invalid.
+     */
+    public function handlePush()
+    {
+        // We only care about push events
+        if ($this->request->header('X-Gogs-Event') !== 'push') {
+            return false;
+        }
+
+        $payload = $this->request->json();
+
+        $commits    = $payload->get('commits');
+        if (! is_array($commits) || count($commits) == 0) {
+            return false;
+        }
+        $head       = array_shift($commits); 
+        $branch     = preg_replace('#refs/(tags|heads)/#', '', $payload->get('ref'));
+
+        return [
+            'reason'          => trim($head['message']),
+            'branch'          => $branch,
+            'source'          => 'Gogs',
+            'build_url'       => $head['url'],
+            'commit'          => $head['id'],
+            'committer'       => $head['committer']['name'],
+            'committer_email' => $head['committer']['email'],
+        ];
+    }
+}

--- a/app/Http/Webhooks/Gogs.php
+++ b/app/Http/Webhooks/Gogs.php
@@ -35,7 +35,7 @@ class Gogs extends Webhook
         if (! is_array($commits) || count($commits) == 0) {
             return false;
         }
-        $head       = array_shift($commits); 
+        $head       = array_shift($commits);
         $branch     = preg_replace('#refs/(tags|heads)/#', '', $payload->get('ref'));
 
         return [

--- a/resources/views/projects/dialogs/webhook.blade.php
+++ b/resources/views/projects/dialogs/webhook.blade.php
@@ -43,7 +43,7 @@
 
                 <hr />
 
-                <h5><strong>{{ Lang::get('commands.services') }} - <i class="fa fa-github"></i> Github, <i class="fa fa-gitlab"></i> Gitlab, <i class="fa fa-bitbucket"></i> Bitbucket &amp; Beanstalk</strong></h5>
+                <h5><strong>{{ Lang::get('commands.services') }} - <i class="fa fa-github"></i> Github, <i class="fa fa-gitlab"></i> Gitlab, <i class="fa fa-bitbucket"></i> Bitbucket, Beanstalk &amp; Gogs/Gitea</strong></h5>
                 <p>{!! Lang::get('commands.services_description') !!}</p>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [contributing guidelines](https://github.com/REBElinBLUE/deployer/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [ ] Do the TravisCI tests pass?
- [ ] Does the StyleCI test pass?

---

### Description of change

We are currently migrating from Slack to Rocket.chat in order to host our data. Rocket.chat webhooks are 100% compatible with Slach webhooks but cannot be used on Deployer as the request is checking the webhook URL format that must match Slack format.
Removing this check and replacing it with a simple URL check should allow anyone to use webhooks for Rocket chat too.
