### PR TITLE
[FIX] Fixes command reordering

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -22,8 +22,8 @@ $router->group(['namespace' => 'Resources'/*, 'prefix' => 'projects/{project}'*/
     $router->resource('commands', 'CommandController', $actions);
 });
 
-$router->group(['namespace' => 'Resources', 'prefix' => 'projects/{project}'], function () use ($router) {
-    $router->get('commands/{step}', 'CommandController@listing')->name('commands.step');
+$router->group(['namespace' => 'Resources'], function () use ($router) {
+    $router->get('projects/{project}/commands/{step}', 'CommandController@listing')->name('commands.step');
     $router->post('commands/reorder', 'CommandController@reorder')->name('commands.reorder');
 });
 

--- a/tests/Integration/Resources/CommandControllerTest.php
+++ b/tests/Integration/Resources/CommandControllerTest.php
@@ -178,7 +178,7 @@ class CommandControllerTest extends AuthenticatedTestCase
         factory(Command::class)->create(array_merge(['name' => 'Foo', 'order' => 2], $target));
         factory(Command::class)->create(array_merge(['name' => 'Bar', 'order' => 1], $target));
 
-        $response = $this->postJson('/projects/1/commands/reorder', ['commands' => [3, 1, 2]]);
+        $response = $this->postJson('/commands/reorder', ['commands' => [3, 1, 2]]);
 
         $response->assertStatus(Response::HTTP_OK)->assertExactJson(['success' => true]);
         $this->assertDatabaseHas('commands', ['id' => 3, 'name' => 'Bar', 'order' => 0]);


### PR DESCRIPTION
Reorder now fails because a POST request is being sent to /commands/reorder and the application only accepts /projects/{project}/commands/reorder due to the prefix in routes/api.php .

Please prefix your pull request with one of the following: **[FEATURE]** **[FIX]** **[IMPROVEMENT]**.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/REBELinBLUE/deployer/blob/master/.github/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I have considered, and confirmed that this submission will be valuable to others.
- [x] Do the TravisCI tests pass?
- [x] Does the StyleCI test pass?

_NOTE: The last 2 are not required to open a PR and can be done afterwards /
while the PR is open._

---

### Description of change

Reorder now fails because a POST request is being sent to /commands/reorder and the application only accepts /projects/{project}/commands/reorder due to the prefix in routes/api.php .

